### PR TITLE
Pattern synonyms

### DIFF
--- a/Boba.Compiler/Renamer.fs
+++ b/Boba.Compiler/Renamer.fs
@@ -107,6 +107,7 @@ module Renamer =
         | DPropagationRule (n, ls, rs) -> DPropagationRule (prefixName prefix n, ls, rs)
         | DTag (tagTy, tagTerm) ->
             DTag (prefixName prefix tagTy, prefixName prefix tagTerm)
+        | DPattern (n, ps, exp) -> DPattern (prefixName prefix n, ps, exp)
         | _ -> failwith $"Renaming not yet implemented for declaration '{decl}'"
 
     let rec extendPatternNameUses env pat =
@@ -302,6 +303,10 @@ module Renamer =
         | DTag (tagTy, tagTerm) ->
             let scope = namesToPrefixFrame prefix [tagTy; tagTerm]
             scope, DTag (tagTy, tagTerm)
+        | DPattern (n, ps, exp) ->
+            let scope = namesToPrefixFrame prefix [n]
+            let paramEnv = namesToPrefixFrame "" ps :: env
+            scope, DPattern (n, ps, extendPatternNameUses paramEnv exp)
         | _ -> failwith $"Renaming not implemented for declaration '{decl}'"
 
     let rec extendDeclsNameUses program prefix env decls =

--- a/Boba.Core.Test/QuineMcCluskeyTest.fs
+++ b/Boba.Core.Test/QuineMcCluskeyTest.fs
@@ -34,3 +34,9 @@ let ``Minimize: a | (b & c) => `` () =
 let ``Minimize: a... | b => a... | b`` () =
     let eqn = BOr (BDotVar "a", BVar "b")
     Assert.StrictEqual(eqn, minimize eqn)
+
+[<Fact>]
+let ``Minimize: a | (b & e) | (b & f) | a | (b & !g) | a => a | (b & e) | (b & f) | (b & !g)`` () =
+    let eqn = BOr (BOr (BOr (BOr (BOr (BVar "a", BAnd (BVar "b", BVar "e")), BAnd (BVar "b", BVar "f")), BVar "a"), BAnd (BVar "f", BNot (BVar "g"))), BVar "a")
+    let sol = BOr (BOr (BOr (BVar "a", BAnd (BVar "b", BVar "e")), BAnd (BVar "b", BVar "f")), BAnd (BVar "f", BNot (BVar "g")))
+    Assert.StrictEqual(sol, minimize eqn)

--- a/Boba.Core/Boolean.fs
+++ b/Boba.Core/Boolean.fs
@@ -36,16 +36,16 @@ module Boolean =
                 | _ -> $"!{b}"
             | BAnd (l, r) ->
                 match l, r with
-                | BOr _, BOr _ -> $"({l})∧({r})"
-                | BOr _, _ -> $"({l})∧{r}"
-                | _, BOr _ -> $"{l}∧({r})"
-                | _, _ -> $"{l}∧{r}"
+                | BOr _, BOr _ -> $"({l})&({r})"
+                | BOr _, _ -> $"({l})&{r}"
+                | _, BOr _ -> $"{l}&({r})"
+                | _, _ -> $"{l}&{r}"
             | BOr (l, r) ->
                 match l, r with
-                | BAnd _, BAnd _ -> $"({l})∨({r})"
-                | BAnd _, _ -> $"({l})∨{r}"
-                | _, BAnd _ -> $"{l}∨({r})"
-                | _, _ -> $"{l}∨{r}"
+                | BAnd _, BAnd _ -> $"({l})|({r})"
+                | BAnd _, _ -> $"({l})|{r}"
+                | _, BAnd _ -> $"{l}|({r})"
+                | _, _ -> $"{l}|{r}"
 
     type MinTermRow = { Name: Set<int>; Row: List<int>; }
 
@@ -386,6 +386,7 @@ module Boolean =
                 List.mapi (toTerm fvs) e.Row
                 |> List.concat
                 |> toSum) finalImplicants
+            |> List.distinct
             |> toProduct
         rigidifyPartial minified rigids
         

--- a/Boba.Core/Types.fs
+++ b/Boba.Core/Types.fs
@@ -735,6 +735,6 @@ module Types =
         let freshies = fresh.FreshN "f" (Seq.length quantified)
         let freshVars = Seq.zip freshies (Seq.map snd quantified) |> Seq.map TVar
         let freshened = Seq.zip (Seq.map fst quantified) freshVars |> Map.ofSeq
-        typeSubstExn fresh freshened body
+        typeSubstSimplifyExn fresh freshened body
 
     let instantiateExn fresh scheme = freshTypeExn fresh scheme.Quantified scheme.Body

--- a/Boba.Core/Unification.fs
+++ b/Boba.Core/Unification.fs
@@ -183,7 +183,7 @@ module Unification =
         | _ when isKindBoolean (typeKindExn l) ->
             let simpL = simplifyType l
             let simpR = simplifyType r
-            printfn $"Sub-unifying {typeToBooleanEqn simpL} ~ {typeToBooleanEqn simpR}"
+            //printfn $"Sub-unifying {typeToBooleanEqn simpL} ~ {typeToBooleanEqn simpR}"
             match Boolean.unify (typeToBooleanEqn simpL) (typeToBooleanEqn simpR) with
             | Some subst ->
                 //printfn $"Resulting sub-unifier:"

--- a/Boba.Core/Unification.fs
+++ b/Boba.Core/Unification.fs
@@ -111,7 +111,7 @@ module Unification =
             Map.empty
         | DotSeq.SInd (li, lss), DotSeq.SInd (ri, rss) ->
             let lu = typeMatchExn fresh li ri
-            let ru = typeMatchExn fresh (typeSubstExn fresh lu (TSeq (lss, primValueKind))) (typeSubstExn fresh lu (TSeq (rss, primValueKind)))
+            let ru = typeMatchExn fresh (typeSubstSimplifyExn fresh lu (TSeq (lss, primValueKind))) (typeSubstSimplifyExn fresh lu (TSeq (rss, primValueKind)))
             mergeSubstExn ru lu
         | DotSeq.SDot (ld, DotSeq.SEnd), DotSeq.SDot (rd, DotSeq.SEnd) ->
             typeMatchExn fresh ld rd
@@ -181,9 +181,12 @@ module Unification =
             //printfn $"Kind mismatch {l} : {typeKindExn l} ~ {r} : {typeKindExn r}"
             raise (UnifyKindMismatch (l, r, typeKindExn l, typeKindExn r))
         | _ when isKindBoolean (typeKindExn l) ->
-            match Boolean.unify (typeToBooleanEqn l) (typeToBooleanEqn r) with
+            let simpL = simplifyType l
+            let simpR = simplifyType r
+            printfn $"Sub-unifying {typeToBooleanEqn simpL} ~ {typeToBooleanEqn simpR}"
+            match Boolean.unify (typeToBooleanEqn simpL) (typeToBooleanEqn simpR) with
             | Some subst ->
-                //printfn $"Boolean unifier of {typeToBooleanEqn l} ~ {typeToBooleanEqn r}:"
+                //printfn $"Resulting sub-unifier:"
                 //Map.iter (fun k v -> printfn $"{k} -> {v}") subst
                 mapValues (booleanEqnToType (typeKindExn l)) subst
             | None -> raise (UnifyBooleanMismatch (l, r))

--- a/test/pattern-synonyms.boba
+++ b/test/pattern-synonyms.boba
@@ -1,16 +1,18 @@
 
-pattern TwoHeadList a b = [ a b ]
+pattern TwoElemList a b = [ a b ]
+
+//pattern Invalid a = [ a b ]
 
 func first-two =
     match {
-        | (TwoHeadList 2 1) => 0
-        | (TwoHeadList a b) => a b add-i32
+        | (TwoElemList 1 2) => 0
+        | (TwoElemList a b) => b a sub-i32
         | else => drop -1
     }
 
-test first-two-spec? = [ 2, 1 ] first-two is 0
-test first-two-gen? = [ 3, 5 ] first-two is 8
-test first-two-three? = [ 5, 2, 1 ] first-two is 0
-test first-two-else? = [ 1 ] first-two is -1
+test first-two-spec? = [ 1, 2 ] first-two is 0
+test first-two-gen? = [ 3, 5 ] first-two is 2
+test first-two-three? = [ 5, 2, 1 ] first-two is -1
+test first-two-one? = [ 1 ] first-two is -1
 
 export { }

--- a/test/pattern-synonyms.boba
+++ b/test/pattern-synonyms.boba
@@ -1,5 +1,5 @@
 
-pattern TwoHeadList a b = [ _... a b ]
+pattern TwoHeadList a b = [ a b ]
 
 func first-two =
     match {

--- a/test/pattern-synonyms.boba
+++ b/test/pattern-synonyms.boba
@@ -1,0 +1,16 @@
+
+pattern TwoHeadList a b = [ _... a b ]
+
+func first-two =
+    match {
+        | (TwoHeadList 2 1) => 0
+        | (TwoHeadList a b) => a b add-i32
+        | else => drop -1
+    }
+
+test first-two-spec? = [ 2, 1 ] first-two is 0
+test first-two-gen? = [ 3, 5 ] first-two is 8
+test first-two-three? = [ 5, 2, 1 ] first-two is 0
+test first-two-else? = [ 1 ] first-two is -1
+
+export { }

--- a/test/patterns.boba
+++ b/test/patterns.boba
@@ -1,0 +1,44 @@
+
+test list-empty-sat? =
+    [] match {
+        | [] => True
+        | else => drop False
+    }
+    satisfies
+
+test list-empty-vio? =
+    [ 1 ] match {
+        | [] => True
+        | else => drop False
+    }
+    violates
+
+test list-one-sat? =
+    [ 1 ] match {
+        | [ 1 ] => True
+        | else => drop False
+    }
+    satisfies
+
+test list-one-vio? =
+    [ 1, 2 ] match {
+        | [ 1 ] => True
+        | else => drop False
+    }
+    violates
+
+test list-two-sat? =
+    [ 1, 2 ] match {
+        | [ 1 2 ] => True
+        | else => drop False
+    }
+    satisfies
+
+test list-two-vio? =
+    [ 2 ] match {
+        | [ 1 2 ] => True
+        | else => drop False
+    }
+    violates
+
+export { }


### PR DESCRIPTION
These can help with complex nested patterns that occur commonly throughout a code base.

Elaboration occurs after type inference, so that type inference errors will reference to the pattern itself instead of the elaborated pattern syntax.

Resolves #29 