### PR TITLE
Ambiguous type context checking implemented

### DIFF
--- a/Boba.Core/CHR.fs
+++ b/Boba.Core/CHR.fs
@@ -236,3 +236,8 @@ module CHR =
         let freshRules = List.map (freshRule fresh) rules
         //Seq.iter (fun r -> printfn $"Rule ===> {r}") freshRules
         solvePredicatesIter fresh [] freshRules (predStore preds)
+    
+    let solveConstraints fresh rules preds eqs =
+        let freshRules = List.map (freshRule fresh) rules
+        //Seq.iter (fun r -> printfn $"Rule ===> {r}") freshRules
+        solvePredicatesIter fresh [] freshRules { Predicates = preds; Equalities = eqs }

--- a/test/ambiguous.boba
+++ b/test/ambiguous.boba
@@ -1,0 +1,11 @@
+// This file fails type inference
+
+overload show as Show? a
+    : z... a^s ===[ e... ][ p... ][ True ]==> z... (String True False)^r
+
+overload read as Read? a
+    : z... (String True False)^s ===[ e... ][ p... ][ True ]==> z... a^r
+
+func ambig = read show
+
+export { }


### PR DESCRIPTION
The compiler will now correctly refuse to allow ambiguous constraint contexts in the inferred type of a function. This required surprisingly less machinery than expected, and could probably be even further simplified.

An example file that the compiler chokes on is included.

Resolves #39 