### PR TITLE
Remove kind param from type sequence constructor

### DIFF
--- a/Boba.Compiler/Condenser.fs
+++ b/Boba.Compiler/Condenser.fs
@@ -151,7 +151,7 @@ module Condenser =
                         Handlers = [
                             for h in e.Handlers ->
                                 let (Some entry) = Environment.lookup env h.Name.Name
-                                let _, _, _, (TSeq (ins, _)), (TSeq (outs, _)) = functionValueTypeComponents (qualTypeHead entry.Type.Body)
+                                let _, _, _, (TSeq ins), (TSeq outs) = functionValueTypeComponents (qualTypeHead entry.Type.Body)
                                 {
                                     Name = h.Name.Name;
                                     Inputs = removeSeqPoly ins |> DotSeq.length;

--- a/Boba.Compiler/KindInference.fs
+++ b/Boba.Compiler/KindInference.fs
@@ -59,7 +59,7 @@ module KindInference =
             if DotSeq.length ts = 0
             then
                 let seqKind = freshKind fresh
-                KSeq seqKind, [], typeSeq DotSeq.SEnd seqKind
+                KSeq seqKind, [], typeSeq DotSeq.SEnd
             else
                 let ks = DotSeq.map (kindInfer fresh env) ts
                 let seqKind =
@@ -69,7 +69,7 @@ module KindInference =
                 let cstrs = DotSeq.map (fun (_, cs, _) -> cs) ks |> DotSeq.fold List.append []
                 let allSeqKindsEq = DotSeq.map (fun (k, _, _) -> kindEqConstraint seqKind k) ks |> DotSeq.toList
                 let allCstrs = append3 [] allSeqKindsEq cstrs
-                KSeq seqKind, allCstrs, TSeq (DotSeq.map (fun (_, _, t) -> t) ks, seqKind)
+                KSeq seqKind, allCstrs, typeSeq (DotSeq.map (fun (_, _, t) -> t) ks)
         | Syntax.STApp (l, r) ->
             let lk, lcstrs, lt = kindInfer fresh env l
             let rk, rcstrs, rt = kindInfer fresh env r

--- a/Boba.Compiler/KindInference.fs
+++ b/Boba.Compiler/KindInference.fs
@@ -55,11 +55,11 @@ module KindInference =
         | Syntax.STRowEmpty ->
             let k = freshKind fresh
             KRow k, [], TEmptyRow k
-        | Syntax.STSeq (ts, k) ->
+        | Syntax.STSeq ts ->
             if DotSeq.length ts = 0
             then
                 let seqKind = freshKind fresh
-                KSeq seqKind, [kindEqConstraint seqKind k], typeSeq DotSeq.SEnd k
+                KSeq seqKind, [], typeSeq DotSeq.SEnd seqKind
             else
                 let ks = DotSeq.map (kindInfer fresh env) ts
                 let seqKind =
@@ -68,8 +68,8 @@ module KindInference =
                     |> (fun (k, _, _) -> k)
                 let cstrs = DotSeq.map (fun (_, cs, _) -> cs) ks |> DotSeq.fold List.append []
                 let allSeqKindsEq = DotSeq.map (fun (k, _, _) -> kindEqConstraint seqKind k) ks |> DotSeq.toList
-                let allCstrs = append3 [kindEqConstraint seqKind k] allSeqKindsEq cstrs
-                KSeq seqKind, allCstrs, TSeq (DotSeq.map (fun (_, _, t) -> t) ks, k)
+                let allCstrs = append3 [] allSeqKindsEq cstrs
+                KSeq seqKind, allCstrs, TSeq (DotSeq.map (fun (_, _, t) -> t) ks, seqKind)
         | Syntax.STApp (l, r) ->
             let lk, lcstrs, lt = kindInfer fresh env l
             let rk, rcstrs, rt = kindInfer fresh env r

--- a/Boba.Compiler/Parser.fs
+++ b/Boba.Compiler/Parser.fs
@@ -3071,7 +3071,7 @@ let _fsyacc_reductions ()  =    [|
                 (
                    (
 # 367 ".\Parser.fsy"
-                                                           appendTypeArgs (stCon primTupleCtorName) [STSeq (_2, primValueKind)] 
+                                                           appendTypeArgs (stCon primTupleCtorName) [STSeq _2] 
                    )
 # 367 ".\Parser.fsy"
                  : 'gentype_base_type));
@@ -3110,831 +3110,829 @@ let _fsyacc_reductions ()  =    [|
                    (
 # 374 ".\Parser.fsy"
                           appendTypeArgs (stCon PrimFunctionCtorName)
-                                     [STSeq (_9, primValueKind);
-                                         STSeq (_1, primValueKind);
-                                         _7; _5; _3] 
+                                     [STSeq _9; STSeq _1; _7; _5; _3] 
                    )
 # 374 ".\Parser.fsy"
                  : 'gentype_fn_type));
-# 3119 "Parser.fs"
+# 3117 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 379 ".\Parser.fsy"
+# 377 ".\Parser.fsy"
                                                SEnd 
                    )
-# 379 ".\Parser.fsy"
+# 377 ".\Parser.fsy"
                  : 'gentype_fn_type_seq));
-# 3129 "Parser.fs"
+# 3127 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_fn_type_seq in
             let _2 = parseState.GetInput(2) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 380 ".\Parser.fsy"
+# 378 ".\Parser.fsy"
                                                                dot _2 _1 
                    )
-# 380 ".\Parser.fsy"
+# 378 ".\Parser.fsy"
                  : 'gentype_fn_type_seq));
-# 3141 "Parser.fs"
+# 3139 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_fn_type_seq in
             let _2 = parseState.GetInput(2) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 381 ".\Parser.fsy"
+# 379 ".\Parser.fsy"
                                                          ind _2 _1 
                    )
-# 381 ".\Parser.fsy"
+# 379 ".\Parser.fsy"
                  : 'gentype_fn_type_seq));
-# 3153 "Parser.fs"
+# 3151 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 383 ".\Parser.fsy"
+# 381 ".\Parser.fsy"
                                                STRowEmpty 
                    )
-# 383 ".\Parser.fsy"
+# 381 ".\Parser.fsy"
                  : 'gentype_fn_row_type));
-# 3163 "Parser.fs"
+# 3161 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 384 ".\Parser.fsy"
+# 382 ".\Parser.fsy"
                                                   STVar _1 
                    )
-# 384 ".\Parser.fsy"
+# 382 ".\Parser.fsy"
                  : 'gentype_fn_row_type));
-# 3174 "Parser.fs"
+# 3172 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_fn_row_type in
             let _3 = parseState.GetInput(3) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 385 ".\Parser.fsy"
+# 383 ".\Parser.fsy"
                                                             appendTypeArgs STRowExtend [_1; _3] 
                    )
-# 385 ".\Parser.fsy"
+# 383 ".\Parser.fsy"
                  : 'gentype_fn_row_type));
-# 3186 "Parser.fs"
+# 3184 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 387 ".\Parser.fsy"
+# 385 ".\Parser.fsy"
                                                    STRowEmpty 
                    )
-# 387 ".\Parser.fsy"
+# 385 ".\Parser.fsy"
                  : 'gentype_field_row_type));
-# 3196 "Parser.fs"
+# 3194 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 388 ".\Parser.fsy"
+# 386 ".\Parser.fsy"
                                                       STVar _1 
                    )
-# 388 ".\Parser.fsy"
+# 386 ".\Parser.fsy"
                  : 'gentype_field_row_type));
-# 3207 "Parser.fs"
+# 3205 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_field_row_type in
             let _3 = parseState.GetInput(3) :?> 'gentype_field_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 389 ".\Parser.fsy"
+# 387 ".\Parser.fsy"
                                                                appendTypeArgs STRowExtend [_1; _3] 
                    )
-# 389 ".\Parser.fsy"
+# 387 ".\Parser.fsy"
                  : 'gentype_field_row_type));
-# 3219 "Parser.fs"
+# 3217 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 391 ".\Parser.fsy"
+# 389 ".\Parser.fsy"
                                                                      appendTypeArgs (STCon { Qualifier = []; Name = _1 }) [_3] 
                    )
-# 391 ".\Parser.fsy"
+# 389 ".\Parser.fsy"
                  : 'gentype_field_type));
-# 3231 "Parser.fs"
+# 3229 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 392 ".\Parser.fsy"
+# 390 ".\Parser.fsy"
                                                   _1 
                    )
-# 392 ".\Parser.fsy"
+# 390 ".\Parser.fsy"
                  : 'gentype_field_type));
-# 3242 "Parser.fs"
+# 3240 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 394 ".\Parser.fsy"
+# 392 ".\Parser.fsy"
                                                        _1 
                    )
-# 394 ".\Parser.fsy"
+# 392 ".\Parser.fsy"
                  : 'gentype_compound_type));
-# 3253 "Parser.fs"
+# 3251 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_val_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 395 ".\Parser.fsy"
+# 393 ".\Parser.fsy"
                                              _1 
                    )
-# 395 ".\Parser.fsy"
+# 393 ".\Parser.fsy"
                  : 'gentype_compound_type));
-# 3264 "Parser.fs"
+# 3262 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_base_type in
             let _3 = parseState.GetInput(3) :?> IntegerLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 396 ".\Parser.fsy"
+# 394 ".\Parser.fsy"
                                                          STExponent (_1, _3) 
                    )
-# 396 ".\Parser.fsy"
+# 394 ".\Parser.fsy"
                  : 'gentype_compound_type));
-# 3276 "Parser.fs"
+# 3274 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_and_sequence in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 397 ".\Parser.fsy"
+# 395 ".\Parser.fsy"
                                                 _1 
                    )
-# 397 ".\Parser.fsy"
+# 395 ".\Parser.fsy"
                  : 'gentype_compound_type));
-# 3287 "Parser.fs"
+# 3285 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_or_sequence in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 398 ".\Parser.fsy"
+# 396 ".\Parser.fsy"
                                                 _1 
                    )
-# 398 ".\Parser.fsy"
+# 396 ".\Parser.fsy"
                  : 'gentype_compound_type));
-# 3298 "Parser.fs"
+# 3296 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_mul_sequence in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 399 ".\Parser.fsy"
+# 397 ".\Parser.fsy"
                                                 _1 
                    )
-# 399 ".\Parser.fsy"
+# 397 ".\Parser.fsy"
                  : 'gentype_compound_type));
-# 3309 "Parser.fs"
+# 3307 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 400 ".\Parser.fsy"
+# 398 ".\Parser.fsy"
                                                     STNot _2 
                    )
-# 400 ".\Parser.fsy"
+# 398 ".\Parser.fsy"
                  : 'gentype_compound_type));
-# 3320 "Parser.fs"
+# 3318 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_base_type in
             let _3 = parseState.GetInput(3) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 402 ".\Parser.fsy"
+# 400 ".\Parser.fsy"
                                                                         STAnd (_1, _3) 
                    )
-# 402 ".\Parser.fsy"
+# 400 ".\Parser.fsy"
                  : 'gentype_and_sequence));
-# 3332 "Parser.fs"
+# 3330 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_and_sequence in
             let _3 = parseState.GetInput(3) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 403 ".\Parser.fsy"
+# 401 ".\Parser.fsy"
                                                                  STAnd (_1, _3) 
                    )
-# 403 ".\Parser.fsy"
+# 401 ".\Parser.fsy"
                  : 'gentype_and_sequence));
-# 3344 "Parser.fs"
+# 3342 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_base_type in
             let _3 = parseState.GetInput(3) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 405 ".\Parser.fsy"
+# 403 ".\Parser.fsy"
                                                                     STOr (_1, _3) 
                    )
-# 405 ".\Parser.fsy"
+# 403 ".\Parser.fsy"
                  : 'gentype_or_sequence));
-# 3356 "Parser.fs"
+# 3354 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_or_sequence in
             let _3 = parseState.GetInput(3) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 406 ".\Parser.fsy"
+# 404 ".\Parser.fsy"
                                                              STOr (_1, _3) 
                    )
-# 406 ".\Parser.fsy"
+# 404 ".\Parser.fsy"
                  : 'gentype_or_sequence));
-# 3368 "Parser.fs"
+# 3366 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_base_type in
             let _3 = parseState.GetInput(3) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 408 ".\Parser.fsy"
+# 406 ".\Parser.fsy"
                                                                 STMultiply (_1, _3) 
                    )
-# 408 ".\Parser.fsy"
+# 406 ".\Parser.fsy"
                  : 'gentype_mul_sequence));
-# 3380 "Parser.fs"
+# 3378 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> IntegerLiteral in
             let _3 = parseState.GetInput(3) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 409 ".\Parser.fsy"
+# 407 ".\Parser.fsy"
                                                      STMultiply (STFixedConst _1, _3) 
                    )
-# 409 ".\Parser.fsy"
+# 407 ".\Parser.fsy"
                  : 'gentype_mul_sequence));
-# 3392 "Parser.fs"
+# 3390 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_base_type in
             let _3 = parseState.GetInput(3) :?> IntegerLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 410 ".\Parser.fsy"
+# 408 ".\Parser.fsy"
                                                      STMultiply (_1, STFixedConst _3) 
                    )
-# 410 ".\Parser.fsy"
+# 408 ".\Parser.fsy"
                  : 'gentype_mul_sequence));
-# 3404 "Parser.fs"
+# 3402 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_mul_sequence in
             let _3 = parseState.GetInput(3) :?> 'gentype_base_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 411 ".\Parser.fsy"
+# 409 ".\Parser.fsy"
                                                          STMultiply (_1, _3) 
                    )
-# 411 ".\Parser.fsy"
+# 409 ".\Parser.fsy"
                  : 'gentype_mul_sequence));
-# 3416 "Parser.fs"
+# 3414 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_mul_sequence in
             let _3 = parseState.GetInput(3) :?> IntegerLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 412 ".\Parser.fsy"
+# 410 ".\Parser.fsy"
                                                        STMultiply (_1, STFixedConst _3) 
                    )
-# 412 ".\Parser.fsy"
+# 410 ".\Parser.fsy"
                  : 'gentype_mul_sequence));
-# 3428 "Parser.fs"
+# 3426 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 414 ".\Parser.fsy"
+# 412 ".\Parser.fsy"
                                                         [_1] 
                    )
-# 414 ".\Parser.fsy"
+# 412 ".\Parser.fsy"
                  : 'gentype_type_arg_list));
-# 3439 "Parser.fs"
+# 3437 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_type_arg_list in
             let _2 = parseState.GetInput(2) :?> 'gentype_compound_type in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 415 ".\Parser.fsy"
+# 413 ".\Parser.fsy"
                                                           List.append _1 [_2] 
                    )
-# 415 ".\Parser.fsy"
+# 413 ".\Parser.fsy"
                  : 'gentype_type_arg_list));
-# 3451 "Parser.fs"
+# 3449 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_term_statement_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 419 ".\Parser.fsy"
+# 417 ".\Parser.fsy"
                                                                                   _2 
                    )
-# 419 ".\Parser.fsy"
+# 417 ".\Parser.fsy"
                  : 'gentype_term_statement_block));
-# 3462 "Parser.fs"
+# 3460 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_term_statement in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 421 ".\Parser.fsy"
+# 419 ".\Parser.fsy"
                                                                    [_1] 
                    )
-# 421 ".\Parser.fsy"
+# 419 ".\Parser.fsy"
                  : 'gentype_term_statement_list));
-# 3473 "Parser.fs"
+# 3471 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_term_statement_list in
             let _3 = parseState.GetInput(3) :?> 'gentype_term_statement in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 422 ".\Parser.fsy"
+# 420 ".\Parser.fsy"
                                                                             List.append _1 [_3] 
                    )
-# 422 ".\Parser.fsy"
+# 420 ".\Parser.fsy"
                  : 'gentype_term_statement_list));
-# 3485 "Parser.fs"
+# 3483 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_no_dot_pattern_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 424 ".\Parser.fsy"
+# 422 ".\Parser.fsy"
                                                                             SLet { Matcher = _2; Body = [] } 
                    )
-# 424 ".\Parser.fsy"
+# 422 ".\Parser.fsy"
                  : 'gentype_term_statement));
-# 3496 "Parser.fs"
+# 3494 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_no_dot_pattern_expr_list in
             let _4 = parseState.GetInput(4) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 425 ".\Parser.fsy"
+# 423 ".\Parser.fsy"
                                                                                          SLet { Matcher = _2; Body = _4 } 
                    )
-# 425 ".\Parser.fsy"
+# 423 ".\Parser.fsy"
                  : 'gentype_term_statement));
-# 3508 "Parser.fs"
+# 3506 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 428 ".\Parser.fsy"
+# 426 ".\Parser.fsy"
                                                               SExpression (_1) 
                    )
-# 428 ".\Parser.fsy"
+# 426 ".\Parser.fsy"
                  : 'gentype_term_statement));
-# 3519 "Parser.fs"
+# 3517 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 435 ".\Parser.fsy"
+# 433 ".\Parser.fsy"
                                                             [_1] 
                    )
-# 435 ".\Parser.fsy"
+# 433 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3530 "Parser.fs"
+# 3528 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_record_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 436 ".\Parser.fsy"
+# 434 ".\Parser.fsy"
                                                      _1 
                    )
-# 436 ".\Parser.fsy"
+# 434 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3541 "Parser.fs"
+# 3539 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_tuple_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 437 ".\Parser.fsy"
+# 435 ".\Parser.fsy"
                                                     _1 
                    )
-# 437 ".\Parser.fsy"
+# 435 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3552 "Parser.fs"
+# 3550 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_list_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 438 ".\Parser.fsy"
+# 436 ".\Parser.fsy"
                                                    _1 
                    )
-# 438 ".\Parser.fsy"
+# 436 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3563 "Parser.fs"
+# 3561 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_non_empty_simple_expr in
             let _2 = parseState.GetInput(2) :?> 'gentype_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 439 ".\Parser.fsy"
+# 437 ".\Parser.fsy"
                                                               List.append _1 [_2] 
                    )
-# 439 ".\Parser.fsy"
+# 437 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3575 "Parser.fs"
+# 3573 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_non_empty_simple_expr in
             let _2 = parseState.GetInput(2) :?> 'gentype_record_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 440 ".\Parser.fsy"
+# 438 ".\Parser.fsy"
                                                                      List.append _1 _2 
                    )
-# 440 ".\Parser.fsy"
+# 438 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3587 "Parser.fs"
+# 3585 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_non_empty_simple_expr in
             let _2 = parseState.GetInput(2) :?> 'gentype_tuple_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 441 ".\Parser.fsy"
+# 439 ".\Parser.fsy"
                                                                      List.append _1 _2 
                    )
-# 441 ".\Parser.fsy"
+# 439 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3599 "Parser.fs"
+# 3597 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_non_empty_simple_expr in
             let _2 = parseState.GetInput(2) :?> 'gentype_list_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 442 ".\Parser.fsy"
+# 440 ".\Parser.fsy"
                                                                     List.append _1 _2 
                    )
-# 442 ".\Parser.fsy"
+# 440 ".\Parser.fsy"
                  : 'gentype_non_empty_simple_expr));
-# 3611 "Parser.fs"
+# 3609 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 444 ".\Parser.fsy"
+# 442 ".\Parser.fsy"
                                             [] 
                    )
-# 444 ".\Parser.fsy"
+# 442 ".\Parser.fsy"
                  : 'gentype_simple_expr));
-# 3621 "Parser.fs"
+# 3619 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 445 ".\Parser.fsy"
+# 443 ".\Parser.fsy"
                                                     _1 
                    )
-# 445 ".\Parser.fsy"
+# 443 ".\Parser.fsy"
                  : 'gentype_simple_expr));
-# 3632 "Parser.fs"
+# 3630 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 449 ".\Parser.fsy"
+# 447 ".\Parser.fsy"
                                                       EStatementBlock (_1) 
                    )
-# 449 ".\Parser.fsy"
+# 447 ".\Parser.fsy"
                  : 'gentype_word));
-# 3643 "Parser.fs"
+# 3641 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_nursery_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 450 ".\Parser.fsy"
+# 448 ".\Parser.fsy"
                                              _1 
                    )
-# 450 ".\Parser.fsy"
+# 448 ".\Parser.fsy"
                  : 'gentype_word));
-# 3654 "Parser.fs"
+# 3652 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_cancellable_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 451 ".\Parser.fsy"
+# 449 ".\Parser.fsy"
                                                 _1 
                    )
-# 451 ".\Parser.fsy"
+# 449 ".\Parser.fsy"
                  : 'gentype_word));
-# 3665 "Parser.fs"
+# 3663 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_handle_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 452 ".\Parser.fsy"
+# 450 ".\Parser.fsy"
                                             _1 
                    )
-# 452 ".\Parser.fsy"
+# 450 ".\Parser.fsy"
                  : 'gentype_word));
-# 3676 "Parser.fs"
+# 3674 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_inject_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 453 ".\Parser.fsy"
+# 451 ".\Parser.fsy"
                                             _1 
                    )
-# 453 ".\Parser.fsy"
+# 451 ".\Parser.fsy"
                  : 'gentype_word));
-# 3687 "Parser.fs"
+# 3685 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_match_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 454 ".\Parser.fsy"
+# 452 ".\Parser.fsy"
                                            _1 
                    )
-# 454 ".\Parser.fsy"
+# 452 ".\Parser.fsy"
                  : 'gentype_word));
-# 3698 "Parser.fs"
+# 3696 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_if_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 455 ".\Parser.fsy"
+# 453 ".\Parser.fsy"
                                          _1 
                    )
-# 455 ".\Parser.fsy"
+# 453 ".\Parser.fsy"
                  : 'gentype_word));
-# 3709 "Parser.fs"
+# 3707 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_switch_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 456 ".\Parser.fsy"
+# 454 ".\Parser.fsy"
                                             _1 
                    )
-# 456 ".\Parser.fsy"
+# 454 ".\Parser.fsy"
                  : 'gentype_word));
-# 3720 "Parser.fs"
+# 3718 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_when_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 457 ".\Parser.fsy"
+# 455 ".\Parser.fsy"
                                           _1 
                    )
-# 457 ".\Parser.fsy"
+# 455 ".\Parser.fsy"
                  : 'gentype_word));
-# 3731 "Parser.fs"
+# 3729 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_while_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 458 ".\Parser.fsy"
+# 456 ".\Parser.fsy"
                                            _1 
                    )
-# 458 ".\Parser.fsy"
+# 456 ".\Parser.fsy"
                  : 'gentype_word));
-# 3742 "Parser.fs"
+# 3740 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_for_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 459 ".\Parser.fsy"
+# 457 ".\Parser.fsy"
                                           _1 
                    )
-# 459 ".\Parser.fsy"
+# 457 ".\Parser.fsy"
                  : 'gentype_word));
-# 3753 "Parser.fs"
+# 3751 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_function_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 460 ".\Parser.fsy"
+# 458 ".\Parser.fsy"
                                                 EFunctionLiteral (_1) 
                    )
-# 460 ".\Parser.fsy"
+# 458 ".\Parser.fsy"
                  : 'gentype_word));
-# 3764 "Parser.fs"
+# 3762 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 466 ".\Parser.fsy"
+# 464 ".\Parser.fsy"
                                                  EExtension (_2) 
                    )
-# 466 ".\Parser.fsy"
+# 464 ".\Parser.fsy"
                  : 'gentype_word));
-# 3775 "Parser.fs"
+# 3773 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 467 ".\Parser.fsy"
+# 465 ".\Parser.fsy"
                                                  ESelect (false, _2) 
                    )
-# 467 ".\Parser.fsy"
+# 465 ".\Parser.fsy"
                  : 'gentype_word));
-# 3786 "Parser.fs"
+# 3784 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 468 ".\Parser.fsy"
+# 466 ".\Parser.fsy"
                                                 ESelect (true, _2) 
                    )
-# 468 ".\Parser.fsy"
+# 466 ".\Parser.fsy"
                  : 'gentype_word));
-# 3797 "Parser.fs"
+# 3795 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_variant_literal in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 470 ".\Parser.fsy"
+# 468 ".\Parser.fsy"
                                                _1 
                    )
-# 470 ".\Parser.fsy"
+# 468 ".\Parser.fsy"
                  : 'gentype_word));
-# 3808 "Parser.fs"
+# 3806 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_case_word in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 471 ".\Parser.fsy"
+# 469 ".\Parser.fsy"
                                           _1 
                    )
-# 471 ".\Parser.fsy"
+# 469 ".\Parser.fsy"
                  : 'gentype_word));
-# 3819 "Parser.fs"
+# 3817 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 472 ".\Parser.fsy"
+# 470 ".\Parser.fsy"
                                                            EWithState (_2) 
                    )
-# 472 ".\Parser.fsy"
+# 470 ".\Parser.fsy"
                  : 'gentype_word));
-# 3830 "Parser.fs"
+# 3828 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_permission in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 473 ".\Parser.fsy"
+# 471 ".\Parser.fsy"
                                            _1 
                    )
-# 473 ".\Parser.fsy"
+# 471 ".\Parser.fsy"
                  : 'gentype_word));
-# 3841 "Parser.fs"
+# 3839 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_tag_expression in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 474 ".\Parser.fsy"
+# 472 ".\Parser.fsy"
                                               _1 
                    )
-# 474 ".\Parser.fsy"
+# 472 ".\Parser.fsy"
                  : 'gentype_word));
-# 3852 "Parser.fs"
+# 3850 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 475 ".\Parser.fsy"
+# 473 ".\Parser.fsy"
                                      EDo 
                    )
-# 475 ".\Parser.fsy"
+# 473 ".\Parser.fsy"
                  : 'gentype_word));
-# 3862 "Parser.fs"
+# 3860 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 477 ".\Parser.fsy"
+# 475 ".\Parser.fsy"
                                        ETrue 
                    )
-# 477 ".\Parser.fsy"
+# 475 ".\Parser.fsy"
                  : 'gentype_word));
-# 3872 "Parser.fs"
+# 3870 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 478 ".\Parser.fsy"
+# 476 ".\Parser.fsy"
                                        EFalse 
                    )
-# 478 ".\Parser.fsy"
+# 476 ".\Parser.fsy"
                  : 'gentype_word));
-# 3882 "Parser.fs"
+# 3880 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> IntegerLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 479 ".\Parser.fsy"
+# 477 ".\Parser.fsy"
                                          EInteger (_1) 
                    )
-# 479 ".\Parser.fsy"
+# 477 ".\Parser.fsy"
                  : 'gentype_word));
-# 3893 "Parser.fs"
+# 3891 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> DecimalLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 480 ".\Parser.fsy"
+# 478 ".\Parser.fsy"
                                          EDecimal (_1) 
                    )
-# 480 ".\Parser.fsy"
+# 478 ".\Parser.fsy"
                  : 'gentype_word));
-# 3904 "Parser.fs"
+# 3902 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> StringLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 481 ".\Parser.fsy"
+# 479 ".\Parser.fsy"
                                         EString (_1) 
                    )
-# 481 ".\Parser.fsy"
+# 479 ".\Parser.fsy"
                  : 'gentype_word));
-# 3915 "Parser.fs"
+# 3913 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> CharacterLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 482 ".\Parser.fsy"
+# 480 ".\Parser.fsy"
                                           ECharacter (_1) 
                    )
-# 482 ".\Parser.fsy"
+# 480 ".\Parser.fsy"
                  : 'gentype_word));
-# 3926 "Parser.fs"
+# 3924 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?>  Identifier  in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 483 ".\Parser.fsy"
+# 481 ".\Parser.fsy"
                                            EIdentifier (_1) 
                    )
-# 483 ".\Parser.fsy"
+# 481 ".\Parser.fsy"
                  : 'gentype_word));
-# 3937 "Parser.fs"
+# 3935 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_param_list in
             let _5 = parseState.GetInput(5) :?> 'gentype_term_statement_block in
@@ -3942,12 +3940,12 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 486 ".\Parser.fsy"
+# 484 ".\Parser.fsy"
                            EWithPermission (_3, _5, _7) 
                    )
-# 486 ".\Parser.fsy"
+# 484 ".\Parser.fsy"
                  : 'gentype_permission));
-# 3950 "Parser.fs"
+# 3948 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_param_list in
             let _5 = parseState.GetInput(5) :?> 'gentype_term_statement_block in
@@ -3955,36 +3953,36 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 488 ".\Parser.fsy"
+# 486 ".\Parser.fsy"
                            EIfPermission (_3, _5, _7) 
                    )
-# 488 ".\Parser.fsy"
+# 486 ".\Parser.fsy"
                  : 'gentype_permission));
-# 3963 "Parser.fs"
+# 3961 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 490 ".\Parser.fsy"
+# 488 ".\Parser.fsy"
                                                                               ENursery(_2, _3) 
                    )
-# 490 ".\Parser.fsy"
+# 488 ".\Parser.fsy"
                  : 'gentype_nursery_word));
-# 3975 "Parser.fs"
+# 3973 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 492 ".\Parser.fsy"
+# 490 ".\Parser.fsy"
                                                                                       ECancellable(_2, _3) 
                    )
-# 492 ".\Parser.fsy"
+# 490 ".\Parser.fsy"
                  : 'gentype_cancellable_word));
-# 3987 "Parser.fs"
+# 3985 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> IntegerLiteral in
             let _3 = parseState.GetInput(3) :?> 'gentype_param_list in
@@ -3994,12 +3992,12 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 495 ".\Parser.fsy"
+# 493 ".\Parser.fsy"
                            EHandle (int _2.Value, _3, _4, _7, _8) 
                    )
-# 495 ".\Parser.fsy"
+# 493 ".\Parser.fsy"
                  : 'gentype_handle_word));
-# 4002 "Parser.fs"
+# 4000 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> IntegerLiteral in
             let _3 = parseState.GetInput(3) :?> 'gentype_param_list in
@@ -4008,12 +4006,12 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 497 ".\Parser.fsy"
+# 495 ".\Parser.fsy"
                            EHandle (int _2.Value, _3, _4, _7, []) 
                    )
-# 497 ".\Parser.fsy"
+# 495 ".\Parser.fsy"
                  : 'gentype_handle_word));
-# 4016 "Parser.fs"
+# 4014 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?>  Identifier  in
             let _3 = parseState.GetInput(3) :?> 'gentype_var_only_pattern_list in
@@ -4021,161 +4019,161 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 500 ".\Parser.fsy"
+# 498 ".\Parser.fsy"
                           { Name = _2; Body = [EStatementBlock([SLet { Matcher = _3; Body = [] }; SExpression(_5)])]; } 
                    )
-# 500 ".\Parser.fsy"
+# 498 ".\Parser.fsy"
                  : 'gentype_handler));
-# 4029 "Parser.fs"
+# 4027 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_var_only_pattern_list in
             let _5 = parseState.GetInput(5) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 503 ".\Parser.fsy"
+# 501 ".\Parser.fsy"
                              [EStatementBlock([SLet { Matcher = _3; Body = [] }; SExpression(_5)])] 
                    )
-# 503 ".\Parser.fsy"
+# 501 ".\Parser.fsy"
                  : 'gentype_return));
-# 4041 "Parser.fs"
+# 4039 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 505 ".\Parser.fsy"
+# 503 ".\Parser.fsy"
                                          [] 
                    )
-# 505 ".\Parser.fsy"
+# 503 ".\Parser.fsy"
                  : 'gentype_param_list));
-# 4051 "Parser.fs"
+# 4049 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_param_list in
             let _2 = parseState.GetInput(2) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 506 ".\Parser.fsy"
+# 504 ".\Parser.fsy"
                                                      List.append _1 [_2] 
                    )
-# 506 ".\Parser.fsy"
+# 504 ".\Parser.fsy"
                  : 'gentype_param_list));
-# 4063 "Parser.fs"
+# 4061 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 508 ".\Parser.fsy"
+# 506 ".\Parser.fsy"
                                            [] 
                    )
-# 508 ".\Parser.fsy"
+# 506 ".\Parser.fsy"
                  : 'gentype_handler_list));
-# 4073 "Parser.fs"
+# 4071 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_handler_list in
             let _2 = parseState.GetInput(2) :?> 'gentype_handler in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 509 ".\Parser.fsy"
+# 507 ".\Parser.fsy"
                                                   List.append _1 [_2] 
                    )
-# 509 ".\Parser.fsy"
+# 507 ".\Parser.fsy"
                  : 'gentype_handler_list));
-# 4085 "Parser.fs"
+# 4083 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_eff_list in
             let _3 = parseState.GetInput(3) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 511 ".\Parser.fsy"
+# 509 ".\Parser.fsy"
                                                                           EInject (_2, _3) 
                    )
-# 511 ".\Parser.fsy"
+# 509 ".\Parser.fsy"
                  : 'gentype_inject_word));
-# 4097 "Parser.fs"
+# 4095 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_type_identifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 513 ".\Parser.fsy"
+# 511 ".\Parser.fsy"
                                                     [_1] 
                    )
-# 513 ".\Parser.fsy"
+# 511 ".\Parser.fsy"
                  : 'gentype_eff_list));
-# 4108 "Parser.fs"
+# 4106 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_type_identifier in
             let _2 = parseState.GetInput(2) :?> 'gentype_eff_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 514 ".\Parser.fsy"
+# 512 ".\Parser.fsy"
                                                      _1 :: _2 
                    )
-# 514 ".\Parser.fsy"
+# 512 ".\Parser.fsy"
                  : 'gentype_eff_list));
-# 4120 "Parser.fs"
+# 4118 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_match_clause_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 516 ".\Parser.fsy"
+# 514 ".\Parser.fsy"
                                                                                    EMatch (_3, []) 
                    )
-# 516 ".\Parser.fsy"
+# 514 ".\Parser.fsy"
                  : 'gentype_match_word));
-# 4131 "Parser.fs"
+# 4129 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_match_clause_list in
             let _7 = parseState.GetInput(7) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 517 ".\Parser.fsy"
+# 515 ".\Parser.fsy"
                                                                                                   EMatch (_3, _7) 
                    )
-# 517 ".\Parser.fsy"
+# 515 ".\Parser.fsy"
                  : 'gentype_match_word));
-# 4143 "Parser.fs"
+# 4141 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_match_clause in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 519 ".\Parser.fsy"
+# 517 ".\Parser.fsy"
                                                             [_1] 
                    )
-# 519 ".\Parser.fsy"
+# 517 ".\Parser.fsy"
                  : 'gentype_match_clause_list));
-# 4154 "Parser.fs"
+# 4152 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_match_clause_list in
             let _2 = parseState.GetInput(2) :?> 'gentype_match_clause in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 520 ".\Parser.fsy"
+# 518 ".\Parser.fsy"
                                                               List.append _1 [_2] 
                    )
-# 520 ".\Parser.fsy"
+# 518 ".\Parser.fsy"
                  : 'gentype_match_clause_list));
-# 4166 "Parser.fs"
+# 4164 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_pattern_expr_list in
             let _4 = parseState.GetInput(4) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 522 ".\Parser.fsy"
+# 520 ".\Parser.fsy"
                                                                                { Matcher = _2; Body = _4 } 
                    )
-# 522 ".\Parser.fsy"
+# 520 ".\Parser.fsy"
                  : 'gentype_match_clause));
-# 4178 "Parser.fs"
+# 4176 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_simple_expr in
             let _4 = parseState.GetInput(4) :?> 'gentype_term_statement_block in
@@ -4183,34 +4181,34 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 524 ".\Parser.fsy"
+# 522 ".\Parser.fsy"
                                                                                                     EIf (_2, _4, _6) 
                    )
-# 524 ".\Parser.fsy"
+# 522 ".\Parser.fsy"
                  : 'gentype_if_word));
-# 4191 "Parser.fs"
+# 4189 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_switch_clause_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 526 ".\Parser.fsy"
+# 524 ".\Parser.fsy"
                                                                                switchClausesToIfs _3 
                    )
-# 526 ".\Parser.fsy"
+# 524 ".\Parser.fsy"
                  : 'gentype_switch_word));
-# 4202 "Parser.fs"
+# 4200 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _4 = parseState.GetInput(4) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 528 ".\Parser.fsy"
+# 526 ".\Parser.fsy"
                                                                                [_4] 
                    )
-# 528 ".\Parser.fsy"
+# 526 ".\Parser.fsy"
                  : 'gentype_switch_clause_list));
-# 4213 "Parser.fs"
+# 4211 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_simple_expr in
             let _4 = parseState.GetInput(4) :?> 'gentype_simple_expr in
@@ -4218,48 +4216,48 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 529 ".\Parser.fsy"
+# 527 ".\Parser.fsy"
                                                                                       _2 :: _4 :: _5 
                    )
-# 529 ".\Parser.fsy"
+# 527 ".\Parser.fsy"
                  : 'gentype_switch_clause_list));
-# 4226 "Parser.fs"
+# 4224 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_simple_expr in
             let _4 = parseState.GetInput(4) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 531 ".\Parser.fsy"
+# 529 ".\Parser.fsy"
                                                                               EIf (_2, _4, []) 
                    )
-# 531 ".\Parser.fsy"
+# 529 ".\Parser.fsy"
                  : 'gentype_when_word));
-# 4238 "Parser.fs"
+# 4236 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_simple_expr in
             let _4 = parseState.GetInput(4) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 533 ".\Parser.fsy"
+# 531 ".\Parser.fsy"
                                                                                 EWhile (_2, _4) 
                    )
-# 533 ".\Parser.fsy"
+# 531 ".\Parser.fsy"
                  : 'gentype_while_word));
-# 4250 "Parser.fs"
+# 4248 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_parallel_sequences in
             let _4 = parseState.GetInput(4) :?> 'gentype_term_statement_block in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 536 ".\Parser.fsy"
+# 534 ".\Parser.fsy"
                           EForEffect (_2, _4) 
                    )
-# 536 ".\Parser.fsy"
+# 534 ".\Parser.fsy"
                  : 'gentype_for_word));
-# 4262 "Parser.fs"
+# 4260 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_parallel_sequences in
             let _4 = parseState.GetInput(4) :?> 'gentype_for_result in
@@ -4267,12 +4265,12 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 538 ".\Parser.fsy"
+# 536 ".\Parser.fsy"
                            EForComprehension ([_4], _2, _6) 
                    )
-# 538 ".\Parser.fsy"
+# 536 ".\Parser.fsy"
                  : 'gentype_for_word));
-# 4275 "Parser.fs"
+# 4273 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_parallel_sequences in
             let _4 = parseState.GetInput(4) :?> 'gentype_fold_inits in
@@ -4280,125 +4278,125 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 540 ".\Parser.fsy"
+# 538 ".\Parser.fsy"
                            EForFold (_4, _2, _6) 
                    )
-# 540 ".\Parser.fsy"
+# 538 ".\Parser.fsy"
                  : 'gentype_for_word));
-# 4288 "Parser.fs"
+# 4286 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_for_result in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 542 ".\Parser.fsy"
+# 540 ".\Parser.fsy"
                                                     [_1] 
                    )
-# 542 ".\Parser.fsy"
+# 540 ".\Parser.fsy"
                  : 'gentype_for_results));
-# 4299 "Parser.fs"
+# 4297 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_for_result in
             let _3 = parseState.GetInput(3) :?> 'gentype_for_results in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 543 ".\Parser.fsy"
+# 541 ".\Parser.fsy"
                                                          _1 :: _3 
                    )
-# 543 ".\Parser.fsy"
+# 541 ".\Parser.fsy"
                  : 'gentype_for_results));
-# 4311 "Parser.fs"
+# 4309 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 545 ".\Parser.fsy"
+# 543 ".\Parser.fsy"
                                            FForTuple 
                    )
-# 545 ".\Parser.fsy"
+# 543 ".\Parser.fsy"
                  : 'gentype_for_result));
-# 4321 "Parser.fs"
+# 4319 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 546 ".\Parser.fsy"
+# 544 ".\Parser.fsy"
                                     FForList 
                    )
-# 546 ".\Parser.fsy"
+# 544 ".\Parser.fsy"
                  : 'gentype_for_result));
-# 4331 "Parser.fs"
+# 4329 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 547 ".\Parser.fsy"
+# 545 ".\Parser.fsy"
                                       FForVector 
                    )
-# 547 ".\Parser.fsy"
+# 545 ".\Parser.fsy"
                  : 'gentype_for_result));
-# 4341 "Parser.fs"
+# 4339 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 548 ".\Parser.fsy"
+# 546 ".\Parser.fsy"
                                          FForString 
                    )
-# 548 ".\Parser.fsy"
+# 546 ".\Parser.fsy"
                  : 'gentype_for_result));
-# 4351 "Parser.fs"
+# 4349 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 550 ".\Parser.fsy"
+# 548 ".\Parser.fsy"
                                              FForTuple 
                    )
-# 550 ".\Parser.fsy"
+# 548 ".\Parser.fsy"
                  : 'gentype_for_sequence));
-# 4361 "Parser.fs"
+# 4359 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 551 ".\Parser.fsy"
+# 549 ".\Parser.fsy"
                                     FForList 
                    )
-# 551 ".\Parser.fsy"
+# 549 ".\Parser.fsy"
                  : 'gentype_for_sequence));
-# 4371 "Parser.fs"
+# 4369 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 552 ".\Parser.fsy"
+# 550 ".\Parser.fsy"
                                      FForVector 
                    )
-# 552 ".\Parser.fsy"
+# 550 ".\Parser.fsy"
                  : 'gentype_for_sequence));
-# 4381 "Parser.fs"
+# 4379 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 553 ".\Parser.fsy"
+# 551 ".\Parser.fsy"
                                         FForString 
                    )
-# 553 ".\Parser.fsy"
+# 551 ".\Parser.fsy"
                  : 'gentype_for_sequence));
-# 4391 "Parser.fs"
+# 4389 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 554 ".\Parser.fsy"
+# 552 ".\Parser.fsy"
                                  FForIterator 
                    )
-# 554 ".\Parser.fsy"
+# 552 ".\Parser.fsy"
                  : 'gentype_for_sequence));
-# 4401 "Parser.fs"
+# 4399 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_for_sequence in
@@ -4406,12 +4404,12 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 557 ".\Parser.fsy"
+# 555 ".\Parser.fsy"
                              [{ Name = _1; SeqType = _3; Assigned = _4 }] 
                    )
-# 557 ".\Parser.fsy"
+# 555 ".\Parser.fsy"
                  : 'gentype_parallel_sequences));
-# 4414 "Parser.fs"
+# 4412 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_for_sequence in
@@ -4420,24 +4418,24 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 559 ".\Parser.fsy"
+# 557 ".\Parser.fsy"
                                 { Name = _1; SeqType = _3; Assigned = _4 } :: _6 
                    )
-# 559 ".\Parser.fsy"
+# 557 ".\Parser.fsy"
                  : 'gentype_parallel_sequences));
-# 4428 "Parser.fs"
+# 4426 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 562 ".\Parser.fsy"
+# 560 ".\Parser.fsy"
                            [{ Name = _1; Assigned = _3 }] 
                    )
-# 562 ".\Parser.fsy"
+# 560 ".\Parser.fsy"
                  : 'gentype_fold_inits));
-# 4440 "Parser.fs"
+# 4438 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_simple_expr in
@@ -4445,609 +4443,609 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 564 ".\Parser.fsy"
+# 562 ".\Parser.fsy"
                               { Name = _1; Assigned = _3; } :: _5 
                    )
-# 564 ".\Parser.fsy"
+# 562 ".\Parser.fsy"
                  : 'gentype_fold_inits));
-# 4453 "Parser.fs"
+# 4451 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 567 ".\Parser.fsy"
+# 565 ".\Parser.fsy"
                             _2 
                    )
-# 567 ".\Parser.fsy"
+# 565 ".\Parser.fsy"
                  : 'gentype_function_literal));
-# 4464 "Parser.fs"
+# 4462 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_var_only_pattern_list in
             let _4 = parseState.GetInput(4) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 569 ".\Parser.fsy"
+# 567 ".\Parser.fsy"
                              [EStatementBlock([SLet { Matcher = _2; Body = [] }; SExpression(_4)])] 
                    )
-# 569 ".\Parser.fsy"
+# 567 ".\Parser.fsy"
                  : 'gentype_function_literal));
-# 4476 "Parser.fs"
+# 4474 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?>  Identifier  in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 572 ".\Parser.fsy"
+# 570 ".\Parser.fsy"
                             ETags ([_2], []) 
                    )
-# 572 ".\Parser.fsy"
+# 570 ".\Parser.fsy"
                  : 'gentype_tag_expression));
-# 4487 "Parser.fs"
+# 4485 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?>  Identifier  in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 574 ".\Parser.fsy"
+# 572 ".\Parser.fsy"
                                ETags ([], [_2]) 
                    )
-# 574 ".\Parser.fsy"
+# 572 ".\Parser.fsy"
                  : 'gentype_tag_expression));
-# 4498 "Parser.fs"
+# 4496 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 576 ".\Parser.fsy"
+# 574 ".\Parser.fsy"
                                ETags ([], []) 
                    )
-# 576 ".\Parser.fsy"
+# 574 ".\Parser.fsy"
                  : 'gentype_tag_expression));
-# 4508 "Parser.fs"
+# 4506 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_identifier_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 578 ".\Parser.fsy"
+# 576 ".\Parser.fsy"
                                ETags (_3, []) 
                    )
-# 578 ".\Parser.fsy"
+# 576 ".\Parser.fsy"
                  : 'gentype_tag_expression));
-# 4519 "Parser.fs"
+# 4517 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _4 = parseState.GetInput(4) :?> 'gentype_identifier_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 580 ".\Parser.fsy"
+# 578 ".\Parser.fsy"
                                ETags ([], _4) 
                    )
-# 580 ".\Parser.fsy"
+# 578 ".\Parser.fsy"
                  : 'gentype_tag_expression));
-# 4530 "Parser.fs"
+# 4528 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_identifier_list in
             let _5 = parseState.GetInput(5) :?> 'gentype_identifier_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 582 ".\Parser.fsy"
+# 580 ".\Parser.fsy"
                                ETags (_3, _5) 
                    )
-# 582 ".\Parser.fsy"
+# 580 ".\Parser.fsy"
                  : 'gentype_tag_expression));
-# 4542 "Parser.fs"
+# 4540 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 584 ".\Parser.fsy"
+# 582 ".\Parser.fsy"
                                                                   [_1] 
                    )
-# 584 ".\Parser.fsy"
+# 582 ".\Parser.fsy"
                  : 'gentype_lit_expr_list));
-# 4553 "Parser.fs"
+# 4551 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_lit_expr_list in
             let _3 = parseState.GetInput(3) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 585 ".\Parser.fsy"
+# 583 ".\Parser.fsy"
                                                                         List.append _1 [_3] 
                    )
-# 585 ".\Parser.fsy"
+# 583 ".\Parser.fsy"
                  : 'gentype_lit_expr_list));
-# 4565 "Parser.fs"
+# 4563 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 587 ".\Parser.fsy"
+# 585 ".\Parser.fsy"
                                                                 [ETupleLiteral []] 
                    )
-# 587 ".\Parser.fsy"
+# 585 ".\Parser.fsy"
                  : 'gentype_tuple_literal));
-# 4575 "Parser.fs"
+# 4573 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_lit_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 588 ".\Parser.fsy"
+# 586 ".\Parser.fsy"
                                                                  ETupleLiteral [] :: expandTupleConsSyntax _2 
                    )
-# 588 ".\Parser.fsy"
+# 586 ".\Parser.fsy"
                  : 'gentype_tuple_literal));
-# 4586 "Parser.fs"
+# 4584 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 589 ".\Parser.fsy"
+# 587 ".\Parser.fsy"
                                                                               [ETupleLiteral _2] 
                    )
-# 589 ".\Parser.fsy"
+# 587 ".\Parser.fsy"
                  : 'gentype_tuple_literal));
-# 4597 "Parser.fs"
+# 4595 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_non_empty_simple_expr in
             let _5 = parseState.GetInput(5) :?> 'gentype_lit_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 590 ".\Parser.fsy"
+# 588 ".\Parser.fsy"
                                                                                             ETupleLiteral _2 :: expandTupleConsSyntax _5 
                    )
-# 590 ".\Parser.fsy"
+# 588 ".\Parser.fsy"
                  : 'gentype_tuple_literal));
-# 4609 "Parser.fs"
+# 4607 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 592 ".\Parser.fsy"
+# 590 ".\Parser.fsy"
                                                                        [EListLiteral []] 
                    )
-# 592 ".\Parser.fsy"
+# 590 ".\Parser.fsy"
                  : 'gentype_list_literal));
-# 4619 "Parser.fs"
+# 4617 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_lit_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 593 ".\Parser.fsy"
+# 591 ".\Parser.fsy"
                                                                         EListLiteral [] :: expandListConsSyntax _2 
                    )
-# 593 ".\Parser.fsy"
+# 591 ".\Parser.fsy"
                  : 'gentype_list_literal));
-# 4630 "Parser.fs"
+# 4628 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 594 ".\Parser.fsy"
+# 592 ".\Parser.fsy"
                                                                                      [EListLiteral _2] 
                    )
-# 594 ".\Parser.fsy"
+# 592 ".\Parser.fsy"
                  : 'gentype_list_literal));
-# 4641 "Parser.fs"
+# 4639 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_non_empty_simple_expr in
             let _5 = parseState.GetInput(5) :?> 'gentype_lit_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 595 ".\Parser.fsy"
+# 593 ".\Parser.fsy"
                                                                                                    EListLiteral _2 :: expandListConsSyntax _5 
                    )
-# 595 ".\Parser.fsy"
+# 593 ".\Parser.fsy"
                  : 'gentype_list_literal));
-# 4653 "Parser.fs"
+# 4651 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_non_empty_simple_expr in
             let _5 = parseState.GetInput(5) :?> 'gentype_field_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 603 ".\Parser.fsy"
+# 601 ".\Parser.fsy"
                                                                                                            ERecordLiteral (_2) :: expandFieldSyntax _5 
                    )
-# 603 ".\Parser.fsy"
+# 601 ".\Parser.fsy"
                  : 'gentype_record_literal));
-# 4665 "Parser.fs"
+# 4663 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_non_empty_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 604 ".\Parser.fsy"
+# 602 ".\Parser.fsy"
                                                                                       [ERecordLiteral (_2)] 
                    )
-# 604 ".\Parser.fsy"
+# 602 ".\Parser.fsy"
                  : 'gentype_record_literal));
-# 4676 "Parser.fs"
+# 4674 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_field_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 605 ".\Parser.fsy"
+# 603 ".\Parser.fsy"
                                                                        ERecordLiteral ([]) :: expandFieldSyntax _2 
                    )
-# 605 ".\Parser.fsy"
+# 603 ".\Parser.fsy"
                  : 'gentype_record_literal));
-# 4687 "Parser.fs"
+# 4685 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 606 ".\Parser.fsy"
+# 604 ".\Parser.fsy"
                                                               [ERecordLiteral ([])] 
                    )
-# 606 ".\Parser.fsy"
+# 604 ".\Parser.fsy"
                  : 'gentype_record_literal));
-# 4697 "Parser.fs"
+# 4695 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_field in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 608 ".\Parser.fsy"
+# 606 ".\Parser.fsy"
                                                              EVariantLiteral (_2) 
                    )
-# 608 ".\Parser.fsy"
+# 606 ".\Parser.fsy"
                  : 'gentype_variant_literal));
-# 4708 "Parser.fs"
+# 4706 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?>  List<CaseClause>  in
             let _7 = parseState.GetInput(7) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 610 ".\Parser.fsy"
+# 608 ".\Parser.fsy"
                                                                                                      ECase (_3, _7) 
                    )
-# 610 ".\Parser.fsy"
+# 608 ".\Parser.fsy"
                  : 'gentype_case_word));
-# 4720 "Parser.fs"
+# 4718 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_case_clause in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 612 ".\Parser.fsy"
+# 610 ".\Parser.fsy"
                                                           [_1] 
                    )
-# 612 ".\Parser.fsy"
+# 610 ".\Parser.fsy"
                  :  List<CaseClause> ));
-# 4731 "Parser.fs"
+# 4729 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?>  List<CaseClause>  in
             let _2 = parseState.GetInput(2) :?> 'gentype_case_clause in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 613 ".\Parser.fsy"
+# 611 ".\Parser.fsy"
                                                            List.append _1 [_2] 
                    )
-# 613 ".\Parser.fsy"
+# 611 ".\Parser.fsy"
                  :  List<CaseClause> ));
-# 4743 "Parser.fs"
+# 4741 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> Name in
             let _4 = parseState.GetInput(4) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 615 ".\Parser.fsy"
+# 613 ".\Parser.fsy"
                                                                        { Tag = _2; Body = _4 } 
                    )
-# 615 ".\Parser.fsy"
+# 613 ".\Parser.fsy"
                  : 'gentype_case_clause));
-# 4755 "Parser.fs"
+# 4753 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_field in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 617 ".\Parser.fsy"
+# 615 ".\Parser.fsy"
                                               [_1] 
                    )
-# 617 ".\Parser.fsy"
+# 615 ".\Parser.fsy"
                  : 'gentype_field_list));
-# 4766 "Parser.fs"
+# 4764 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_field in
             let _3 = parseState.GetInput(3) :?> 'gentype_field_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 618 ".\Parser.fsy"
+# 616 ".\Parser.fsy"
                                                      _1 :: _3 
                    )
-# 618 ".\Parser.fsy"
+# 616 ".\Parser.fsy"
                  : 'gentype_field_list));
-# 4778 "Parser.fs"
+# 4776 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_simple_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 620 ".\Parser.fsy"
+# 618 ".\Parser.fsy"
                                                              (_1, _3) 
                    )
-# 620 ".\Parser.fsy"
+# 618 ".\Parser.fsy"
                  : 'gentype_field));
-# 4790 "Parser.fs"
+# 4788 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?>  Identifier  in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 622 ".\Parser.fsy"
+# 620 ".\Parser.fsy"
                                                         [_1] 
                    )
-# 622 ".\Parser.fsy"
+# 620 ".\Parser.fsy"
                  : 'gentype_identifier_list));
-# 4801 "Parser.fs"
+# 4799 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_identifier_list in
             let _2 = parseState.GetInput(2) :?>  Identifier  in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 623 ".\Parser.fsy"
+# 621 ".\Parser.fsy"
                                                         List.append _1 [_2] 
                    )
-# 623 ".\Parser.fsy"
+# 621 ".\Parser.fsy"
                  : 'gentype_identifier_list));
-# 4813 "Parser.fs"
+# 4811 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_qualified_name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 625 ".\Parser.fsy"
+# 623 ".\Parser.fsy"
                                                    sIdentifier (List.take (List.length _1 - 1) _1) (List.last _1) 
                    )
-# 625 ".\Parser.fsy"
+# 623 ".\Parser.fsy"
                  :  Identifier ));
-# 4824 "Parser.fs"
+# 4822 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_qualified_ctor in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 627 ".\Parser.fsy"
+# 625 ".\Parser.fsy"
                                                         sIdentifier (List.take (List.length _1 - 1) _1) (List.last _1) 
                    )
-# 627 ".\Parser.fsy"
+# 625 ".\Parser.fsy"
                  : 'gentype_type_identifier));
-# 4835 "Parser.fs"
+# 4833 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_qualified_pred in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 629 ".\Parser.fsy"
+# 627 ".\Parser.fsy"
                                                         sIdentifier (List.take (List.length _1 - 1) _1) (List.last _1) 
                    )
-# 629 ".\Parser.fsy"
+# 627 ".\Parser.fsy"
                  : 'gentype_pred_identifier));
-# 4846 "Parser.fs"
+# 4844 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 631 ".\Parser.fsy"
+# 629 ".\Parser.fsy"
                                                           [_1] 
                    )
-# 631 ".\Parser.fsy"
+# 629 ".\Parser.fsy"
                  : 'gentype_qualified_name));
-# 4857 "Parser.fs"
+# 4855 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 632 ".\Parser.fsy"
+# 630 ".\Parser.fsy"
                                                [_1] 
                    )
-# 632 ".\Parser.fsy"
+# 630 ".\Parser.fsy"
                  : 'gentype_qualified_name));
-# 4868 "Parser.fs"
+# 4866 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 633 ".\Parser.fsy"
+# 631 ".\Parser.fsy"
                                                    [_1] 
                    )
-# 633 ".\Parser.fsy"
+# 631 ".\Parser.fsy"
                  : 'gentype_qualified_name));
-# 4879 "Parser.fs"
+# 4877 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 634 ".\Parser.fsy"
+# 632 ".\Parser.fsy"
                                                     [_1] 
                    )
-# 634 ".\Parser.fsy"
+# 632 ".\Parser.fsy"
                  : 'gentype_qualified_name));
-# 4890 "Parser.fs"
+# 4888 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_qualified_name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 635 ".\Parser.fsy"
+# 633 ".\Parser.fsy"
                                                                       _1 :: _3 
                    )
-# 635 ".\Parser.fsy"
+# 633 ".\Parser.fsy"
                  : 'gentype_qualified_name));
-# 4902 "Parser.fs"
+# 4900 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 637 ".\Parser.fsy"
+# 635 ".\Parser.fsy"
                                                         [_1] 
                    )
-# 637 ".\Parser.fsy"
+# 635 ".\Parser.fsy"
                  : 'gentype_qualified_ctor));
-# 4913 "Parser.fs"
+# 4911 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 638 ".\Parser.fsy"
+# 636 ".\Parser.fsy"
                                                    [_1] 
                    )
-# 638 ".\Parser.fsy"
+# 636 ".\Parser.fsy"
                  : 'gentype_qualified_ctor));
-# 4924 "Parser.fs"
+# 4922 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_qualified_ctor in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 639 ".\Parser.fsy"
+# 637 ".\Parser.fsy"
                                                                       _1 :: _3 
                    )
-# 639 ".\Parser.fsy"
+# 637 ".\Parser.fsy"
                  : 'gentype_qualified_ctor));
-# 4936 "Parser.fs"
+# 4934 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 641 ".\Parser.fsy"
+# 639 ".\Parser.fsy"
                                                              [_1] 
                    )
-# 641 ".\Parser.fsy"
+# 639 ".\Parser.fsy"
                  : 'gentype_qualified_pred));
-# 4947 "Parser.fs"
+# 4945 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_qualified_pred in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 642 ".\Parser.fsy"
+# 640 ".\Parser.fsy"
                                                                       _1 :: _3 
                    )
-# 642 ".\Parser.fsy"
+# 640 ".\Parser.fsy"
                  : 'gentype_qualified_pred));
-# 4959 "Parser.fs"
+# 4957 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 646 ".\Parser.fsy"
+# 644 ".\Parser.fsy"
                                                                       ind _1 SEnd 
                    )
-# 646 ".\Parser.fsy"
+# 644 ".\Parser.fsy"
                  : 'gentype_no_dot_pattern_expr_list));
-# 4970 "Parser.fs"
+# 4968 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_no_dot_pattern_expr_list in
             let _2 = parseState.GetInput(2) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 647 ".\Parser.fsy"
+# 645 ".\Parser.fsy"
                                                                       ind _2 _1 
                    )
-# 647 ".\Parser.fsy"
+# 645 ".\Parser.fsy"
                  : 'gentype_no_dot_pattern_expr_list));
-# 4982 "Parser.fs"
+# 4980 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 649 ".\Parser.fsy"
+# 647 ".\Parser.fsy"
                                                         SEnd 
                    )
-# 649 ".\Parser.fsy"
+# 647 ".\Parser.fsy"
                  : 'gentype_var_only_pattern_list));
-# 4992 "Parser.fs"
+# 4990 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _2 = parseState.GetInput(2) :?> 'gentype_var_only_pattern_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 650 ".\Parser.fsy"
+# 648 ".\Parser.fsy"
                                                                  ind (PNamed (_1, PWildcard)) _2 
                    )
-# 650 ".\Parser.fsy"
+# 648 ".\Parser.fsy"
                  : 'gentype_var_only_pattern_list));
-# 5004 "Parser.fs"
+# 5002 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 652 ".\Parser.fsy"
+# 650 ".\Parser.fsy"
                                                             ind _1 SEnd 
                    )
-# 652 ".\Parser.fsy"
+# 650 ".\Parser.fsy"
                  : 'gentype_pattern_expr_list));
-# 5015 "Parser.fs"
+# 5013 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 653 ".\Parser.fsy"
+# 651 ".\Parser.fsy"
                                                        dot _1 SEnd 
                    )
-# 653 ".\Parser.fsy"
+# 651 ".\Parser.fsy"
                  : 'gentype_pattern_expr_list));
-# 5026 "Parser.fs"
+# 5024 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_pattern_expr_list in
             let _2 = parseState.GetInput(2) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 654 ".\Parser.fsy"
+# 652 ".\Parser.fsy"
                                                                ind _2 _1 
                    )
-# 654 ".\Parser.fsy"
+# 652 ".\Parser.fsy"
                  : 'gentype_pattern_expr_list));
-# 5038 "Parser.fs"
+# 5036 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 656 ".\Parser.fsy"
+# 654 ".\Parser.fsy"
                                                                                   [(_1, _3)] 
                    )
-# 656 ".\Parser.fsy"
+# 654 ".\Parser.fsy"
                  : 'gentype_field_pattern_list));
-# 5050 "Parser.fs"
+# 5048 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_pattern_expr in
@@ -5055,274 +5053,274 @@ let _fsyacc_reductions ()  =    [|
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 657 ".\Parser.fsy"
+# 655 ".\Parser.fsy"
                                                                                         (_1, _3) :: _5 
                    )
-# 657 ".\Parser.fsy"
+# 655 ".\Parser.fsy"
                  : 'gentype_field_pattern_list));
-# 5063 "Parser.fs"
+# 5061 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 659 ".\Parser.fsy"
+# 657 ".\Parser.fsy"
                                                       PTrue 
                    )
-# 659 ".\Parser.fsy"
+# 657 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5073 "Parser.fs"
+# 5071 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 660 ".\Parser.fsy"
+# 658 ".\Parser.fsy"
                                              PFalse 
                    )
-# 660 ".\Parser.fsy"
+# 658 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5083 "Parser.fs"
+# 5081 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> IntegerLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 661 ".\Parser.fsy"
+# 659 ".\Parser.fsy"
                                                PInteger (_1) 
                    )
-# 661 ".\Parser.fsy"
+# 659 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5094 "Parser.fs"
+# 5092 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> DecimalLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 662 ".\Parser.fsy"
+# 660 ".\Parser.fsy"
                                                PDecimal (_1) 
                    )
-# 662 ".\Parser.fsy"
+# 660 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5105 "Parser.fs"
+# 5103 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> StringLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 663 ".\Parser.fsy"
+# 661 ".\Parser.fsy"
                                               PString (_1) 
                    )
-# 663 ".\Parser.fsy"
+# 661 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5116 "Parser.fs"
+# 5114 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> CharacterLiteral in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 664 ".\Parser.fsy"
+# 662 ".\Parser.fsy"
                                                 PRune (_1) 
                    )
-# 664 ".\Parser.fsy"
+# 662 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5127 "Parser.fs"
+# 5125 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 665 ".\Parser.fsy"
+# 663 ".\Parser.fsy"
                                                  PWildcard 
                    )
-# 665 ".\Parser.fsy"
+# 663 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5137 "Parser.fs"
+# 5135 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 666 ".\Parser.fsy"
+# 664 ".\Parser.fsy"
                                                       PRef (_2) 
                    )
-# 666 ".\Parser.fsy"
+# 664 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5148 "Parser.fs"
+# 5146 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 667 ".\Parser.fsy"
+# 665 ".\Parser.fsy"
                                                  PNamed (_1, PWildcard) 
                    )
-# 667 ".\Parser.fsy"
+# 665 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5159 "Parser.fs"
+# 5157 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> Name in
             let _3 = parseState.GetInput(3) :?> 'gentype_pattern_expr in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 668 ".\Parser.fsy"
+# 666 ".\Parser.fsy"
                                                               PNamed (_1, _3) 
                    )
-# 668 ".\Parser.fsy"
+# 666 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5171 "Parser.fs"
+# 5169 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_type_identifier in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 670 ".\Parser.fsy"
+# 668 ".\Parser.fsy"
                             PConstructor (_1, SEnd) 
                    )
-# 670 ".\Parser.fsy"
+# 668 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5182 "Parser.fs"
+# 5180 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_type_identifier in
             let _3 = parseState.GetInput(3) :?> 'gentype_pattern_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 672 ".\Parser.fsy"
+# 670 ".\Parser.fsy"
                             PConstructor (_2, _3) 
                    )
-# 672 ".\Parser.fsy"
+# 670 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5194 "Parser.fs"
+# 5192 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_tuple_pattern in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 673 ".\Parser.fsy"
+# 671 ".\Parser.fsy"
                                                    _1 
                    )
-# 673 ".\Parser.fsy"
+# 671 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5205 "Parser.fs"
+# 5203 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_list_pattern in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 674 ".\Parser.fsy"
+# 672 ".\Parser.fsy"
                                                    _1 
                    )
-# 674 ".\Parser.fsy"
+# 672 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5216 "Parser.fs"
+# 5214 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_vector_pattern in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 675 ".\Parser.fsy"
+# 673 ".\Parser.fsy"
                                                     _1 
                    )
-# 675 ".\Parser.fsy"
+# 673 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5227 "Parser.fs"
+# 5225 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_slice_pattern in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 676 ".\Parser.fsy"
+# 674 ".\Parser.fsy"
                                                    _1 
                    )
-# 676 ".\Parser.fsy"
+# 674 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5238 "Parser.fs"
+# 5236 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _1 = parseState.GetInput(1) :?> 'gentype_record_pattern in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 677 ".\Parser.fsy"
+# 675 ".\Parser.fsy"
                                                     _1 
                    )
-# 677 ".\Parser.fsy"
+# 675 ".\Parser.fsy"
                  : 'gentype_pattern_expr));
-# 5249 "Parser.fs"
+# 5247 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_pattern_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 679 ".\Parser.fsy"
+# 677 ".\Parser.fsy"
                                                                        PTuple (_2) 
                    )
-# 679 ".\Parser.fsy"
+# 677 ".\Parser.fsy"
                  : 'gentype_tuple_pattern));
-# 5260 "Parser.fs"
+# 5258 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 680 ".\Parser.fsy"
+# 678 ".\Parser.fsy"
                                                  PTuple (SEnd) 
                    )
-# 680 ".\Parser.fsy"
+# 678 ".\Parser.fsy"
                  : 'gentype_tuple_pattern));
-# 5270 "Parser.fs"
+# 5268 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_pattern_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 682 ".\Parser.fsy"
+# 680 ".\Parser.fsy"
                                                                               PList (_2) 
                    )
-# 682 ".\Parser.fsy"
+# 680 ".\Parser.fsy"
                  : 'gentype_list_pattern));
-# 5281 "Parser.fs"
+# 5279 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 683 ".\Parser.fsy"
+# 681 ".\Parser.fsy"
                                                         PList (SEnd) 
                    )
-# 683 ".\Parser.fsy"
+# 681 ".\Parser.fsy"
                  : 'gentype_list_pattern));
-# 5291 "Parser.fs"
+# 5289 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_pattern_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 685 ".\Parser.fsy"
+# 683 ".\Parser.fsy"
                                                                                   PVector (_3) 
                    )
-# 685 ".\Parser.fsy"
+# 683 ".\Parser.fsy"
                  : 'gentype_vector_pattern));
-# 5302 "Parser.fs"
+# 5300 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _3 = parseState.GetInput(3) :?> 'gentype_pattern_expr_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 687 ".\Parser.fsy"
+# 685 ".\Parser.fsy"
                                                                                  PSlice (_3) 
                    )
-# 687 ".\Parser.fsy"
+# 685 ".\Parser.fsy"
                  : 'gentype_slice_pattern));
-# 5313 "Parser.fs"
+# 5311 "Parser.fs"
         (fun (parseState : FSharp.Text.Parsing.IParseState) ->
             let _2 = parseState.GetInput(2) :?> 'gentype_field_pattern_list in
             Microsoft.FSharp.Core.Operators.box
                 (
                    (
-# 689 ".\Parser.fsy"
+# 687 ".\Parser.fsy"
                                                                                  PRecord (_2) 
                    )
-# 689 ".\Parser.fsy"
+# 687 ".\Parser.fsy"
                  : 'gentype_record_pattern));
 |]
-# 5325 "Parser.fs"
+# 5323 "Parser.fs"
 let tables : FSharp.Text.Parsing.Tables<_> = 
   { reductions= _fsyacc_reductions ();
     endOfInputTag = _fsyacc_endOfInputTag;

--- a/Boba.Compiler/Parser.fsy
+++ b/Boba.Compiler/Parser.fsy
@@ -364,7 +364,7 @@ base_type : TRUE											{ STTrue }
 		  | L_BRACKET R_BRACKET								{ stCon primListCtorName }
 		  | L_BRACKET compound_type R_BRACKET				{ appendTypeArgs (stCon primListCtorName) [$2] }
 		  | L_BOX ELLIPSIS R_BOX							{ stCon primTupleCtorName }
-		  | L_BOX fn_type_seq R_BOX							{ appendTypeArgs (stCon primTupleCtorName) [STSeq ($2, primValueKind)] }
+		  | L_BOX fn_type_seq R_BOX							{ appendTypeArgs (stCon primTupleCtorName) [STSeq $2] }
 
 val_type : base_type CARET base_type			{ appendTypeArgs (stCon PrimTrackedCtorName) [$3; $1] }
 
@@ -372,9 +372,7 @@ top_fn_type : fn_type	{ appendTypeArgs (stCon PrimTrackedCtorName) [STFalse; $1]
 
 fn_type : fn_type_seq FN_ARROW_BACK fn_row_type FN_DIVIDE fn_row_type FN_DIVIDE compound_type FN_ARROW_FRONT fn_type_seq
 			{ appendTypeArgs (stCon PrimFunctionCtorName)
-                [STSeq ($9, primValueKind);
-                    STSeq ($1, primValueKind);
-                    $7; $5; $3] }
+                [STSeq $9; STSeq $1; $7; $5; $3] }
 
 fn_type_seq : 										{ SEnd }
 			| fn_type_seq compound_type ELLIPSIS	{ dot $2 $1 }

--- a/Boba.Compiler/Renamer.fs
+++ b/Boba.Compiler/Renamer.fs
@@ -260,7 +260,7 @@ module Renamer =
         | STNot b -> STNot (extendTypeNameUses env b)
         | STExponent (l, p) -> STExponent (extendTypeNameUses env l, p)
         | STMultiply (l, r) -> STMultiply (extendTypeNameUses env l, extendTypeNameUses env r)
-        | STSeq (s, k) -> STSeq (Boba.Core.DotSeq.map (extendTypeNameUses env) s, k)
+        | STSeq s -> STSeq (Boba.Core.DotSeq.map (extendTypeNameUses env) s)
         | STApp (l, r) -> STApp (extendTypeNameUses env l, extendTypeNameUses env r)
         | _ -> ty
     

--- a/Boba.Compiler/Syntax.fs
+++ b/Boba.Compiler/Syntax.fs
@@ -420,7 +420,7 @@ module Syntax =
         | STFixedConst of IntegerLiteral
         | STRowExtend
         | STRowEmpty
-        | STSeq of DotSeq<SType> * Kind
+        | STSeq of DotSeq<SType>
         | STApp of SType * SType
     
     let stCon name = STCon { Qualifier = []; Name = stringToBigName name }
@@ -438,12 +438,12 @@ module Syntax =
         | STNot b -> stypeFree b
         | STExponent (b, _) -> stypeFree b
         | STMultiply (l, r) -> Set.union (stypeFree l) (stypeFree r)
-        | STSeq (ts, _) -> toList ts |> List.map stypeFree |> Set.unionMany
+        | STSeq ts -> toList ts |> List.map stypeFree |> Set.unionMany
         | STApp (l, r) -> Set.union (stypeFree l) (stypeFree r)
         | _ -> Set.empty
 
     let sQualType context head =
-        STApp (STApp (stCon PrimConstrainedCtorName, STApp (stCon PrimConstraintTupleCtorName, STSeq (context, primConstraintKind))), head)
+        STApp (STApp (stCon PrimConstrainedCtorName, STApp (stCon PrimConstraintTupleCtorName, STSeq context)), head)
     
     let sIdentifier qualifier name =
         { Qualifier = qualifier; Name = name; }

--- a/Boba.Compiler/TypeInference.fs
+++ b/Boba.Compiler/TypeInference.fs
@@ -52,7 +52,7 @@ module TypeInference =
 
     /// Generates a simple polymorphic expression type of the form `(a... -> a...)`
     let freshIdentity (fresh : FreshVars) =
-        let io = typeValueSeq (freshSequenceVar fresh)
+        let io = typeSeq (freshSequenceVar fresh)
         let e = freshEffectVar fresh
         let p = freshPermVar fresh
         unqualType (mkExpressionType e p totalAttr io io)
@@ -60,8 +60,8 @@ module TypeInference =
     /// Generates a simple polymorphic expression type of the form `(a... -> b...)`
     /// Useful for recursive function templates. Totality of the generated type is polymorphic.
     let freshTransform (fresh : FreshVars) =
-        let i = typeValueSeq (freshSequenceVar fresh)
-        let o = typeValueSeq (freshSequenceVar fresh)
+        let i = typeSeq (freshSequenceVar fresh)
+        let o = typeSeq (freshSequenceVar fresh)
         let (e, p, t) = freshFunctionAttributes fresh
         unqualType (mkExpressionType e p t i o)
 
@@ -69,8 +69,8 @@ module TypeInference =
     let freshPush (fresh : FreshVars) total ty =
         assert (typeKindExn ty = primValueKind)
         let rest = freshSequenceVar fresh
-        let i = typeValueSeq rest
-        let o = typeValueSeq (DotSeq.SInd (ty, rest))
+        let i = typeSeq rest
+        let o = typeSeq (DotSeq.SInd (ty, rest))
         let e = freshEffectVar fresh
         let p = freshPermVar fresh
         unqualType (mkExpressionType e p total i o)
@@ -78,8 +78,8 @@ module TypeInference =
     let freshPushMany (fresh : FreshVars) total tys =
         assert (List.forall (fun t -> typeKindExn t = primValueKind) tys)
         let rest = freshSequenceVar fresh
-        let i = typeValueSeq rest
-        let o = typeValueSeq (DotSeq.append (DotSeq.ofList (List.rev tys)) rest)
+        let i = typeSeq rest
+        let o = typeSeq (DotSeq.append (DotSeq.ofList (List.rev tys)) rest)
         let e = freshEffectVar fresh
         let p = freshPermVar fresh
         unqualType (mkExpressionType e p total i o)
@@ -88,8 +88,8 @@ module TypeInference =
         assert (List.forall (fun t -> typeKindExn t = primValueKind) pops)
         assert (List.forall (fun t -> typeKindExn t = primValueKind) pushes)
         let rest = freshSequenceVar fresh
-        let i = typeValueSeq (DotSeq.append (DotSeq.ofList (List.rev pops)) rest)
-        let o = typeValueSeq (DotSeq.append (DotSeq.ofList (List.rev pushes)) rest)
+        let i = typeSeq (DotSeq.append (DotSeq.ofList (List.rev pops)) rest)
+        let o = typeSeq (DotSeq.append (DotSeq.ofList (List.rev pushes)) rest)
         let e = freshEffectVar fresh
         let p = freshPermVar fresh
         unqualType (mkExpressionType e p total i o)
@@ -99,8 +99,8 @@ module TypeInference =
         assert (typeKindExn valIn = primValueKind)
         assert (typeKindExn valOut = primValueKind)
         let rest = freshSequenceVar fresh
-        let i = typeValueSeq (DotSeq.ind valIn rest)
-        let o = typeValueSeq (DotSeq.ind valOut rest)
+        let i = typeSeq (DotSeq.ind valIn rest)
+        let o = typeSeq (DotSeq.ind valOut rest)
         let e = freshEffectVar fresh
         let p = freshPermVar fresh
         unqualType (mkExpressionType e p totalAttr i o)
@@ -111,8 +111,8 @@ module TypeInference =
     /// Generates a simple polymorphic expression type of the form `(a... tyN ... ty2 ty1 -> a...)` assumed to be total.
     let freshPopped (fresh: FreshVars) tys =
         let rest = freshSequenceVar fresh
-        let o = typeValueSeq rest
-        let i = typeValueSeq (DotSeq.append (DotSeq.ofList (List.rev tys)) rest)
+        let o = typeSeq rest
+        let i = typeSeq (DotSeq.append (DotSeq.ofList (List.rev tys)) rest)
         let e = freshEffectVar fresh
         let p = freshPermVar fresh
         unqualType (mkExpressionType e p totalAttr i o)
@@ -120,9 +120,9 @@ module TypeInference =
     /// Generate a qualified type of the form `(a... ty1 ty2 ... --> a... ty3 t4 ...)`.
     let freshResume (fresh: FreshVars) tys outs =
         let freshI = freshSequenceVar fresh
-        let i = typeValueSeq (DotSeq.append (DotSeq.ofList (List.rev tys)) freshI)
+        let i = typeSeq (DotSeq.append (DotSeq.ofList (List.rev tys)) freshI)
         let (e, p, t) = freshFunctionAttributes fresh
-        unqualType (mkExpressionType e p t i (typeValueSeq outs))
+        unqualType (mkExpressionType e p t i (typeSeq outs))
     
     /// The sharing attribute on a closure is the disjunction of all of the free variables referenced
     /// by the closure, forcing it to be unique if any of the free variables it references are also unique.
@@ -304,7 +304,7 @@ module TypeInference =
             List.concat vs, List.append constrs (List.concat cs), recTy
         | Syntax.PConstructor (name, ps) ->
             let vs, cs, infPs = DotSeq.map (inferPattern fresh env) ps |> DotSeq.toList |> List.unzip3
-            let (TSeq (templateTy, _)) = instantiateExn fresh (getPatternEntry env name.Name.Name)
+            let (TSeq templateTy) = instantiateExn fresh (getPatternEntry env name.Name.Name)
 
             // build a constructor type that enforces sharing attributes
             let all = DotSeq.toList templateTy
@@ -400,16 +400,16 @@ module TypeInference =
             let shareCnstrs, shareTy = sharedClosure fresh env exp
             let asValue = mkValueType (valueTypeData eTyHead) shareTy
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq rest
-            let o = typeValueSeq (DotSeq.ind asValue rest)
+            let i = typeSeq rest
+            let o = typeSeq (DotSeq.ind asValue rest)
             (qualType eTyContext (mkExpressionType ne np totalAttr i o), List.append shareCnstrs eCnstrs, [Syntax.EFunctionLiteral ePlc])
         | Syntax.ETupleLiteral [] ->
             // tuple literals with no splat expression just create an empty tuple
             let ne = freshEffectVar fresh
             let np = freshPermVar fresh
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq rest
-            let o = typeValueSeq (DotSeq.ind (mkTupleType DotSeq.SEnd (freshShareVar fresh)) rest)
+            let i = typeSeq rest
+            let o = typeSeq (DotSeq.ind (mkTupleType DotSeq.SEnd (freshShareVar fresh)) rest)
             (unqualType (mkExpressionType ne np totalAttr i o), [], [Syntax.ETupleLiteral []])
         | Syntax.ETupleLiteral exp ->
             // TODO: this doesn't seem like it will handle gather/spread semantics for stack splatting
@@ -420,7 +420,7 @@ module TypeInference =
             let ns = mkValueType (freshDataVar fresh) (freshShareVar fresh)
             let tupVal = mkTupleType (DotSeq.dot ns DotSeq.SEnd) (freshShareVar fresh)
             let rest = freshSequenceVar fresh
-            let io = typeValueSeq (DotSeq.ind tupVal rest)
+            let io = typeSeq (DotSeq.ind tupVal rest)
             let verifyTupTop = unqualType (mkExpressionType ne np totalAttr io io)
             let (infVer, constrsVer) = composeWordTypes infExp verifyTupTop
             infVer, List.append constrsExp constrsVer, [Syntax.ETupleLiteral expExpand]
@@ -430,8 +430,8 @@ module TypeInference =
             let ns = freshValueVar fresh
             let listVal = mkListType ns (freshShareVar fresh)
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq rest
-            let o = typeValueSeq (DotSeq.ind listVal rest)
+            let i = typeSeq rest
+            let o = typeSeq (DotSeq.ind listVal rest)
             unqualType (mkExpressionType ne np totalAttr i o), [], [Syntax.EListLiteral []]
         | Syntax.EListLiteral exp ->
             let (infExp, constrsExp, expExpand) = inferExpr fresh env exp
@@ -440,7 +440,7 @@ module TypeInference =
             let ns = freshValueVar fresh
             let listVal = mkListType ns (freshShareVar fresh)
             let rest = freshSequenceVar fresh
-            let io = typeValueSeq (DotSeq.ind listVal rest)
+            let io = typeSeq (DotSeq.ind listVal rest)
             let verifyListTop = unqualType (mkExpressionType ne np totalAttr io io)
             let (infVer, constrsVer) = composeWordTypes infExp verifyListTop
             infVer, List.append constrsExp constrsVer, [Syntax.EListLiteral expExpand]
@@ -449,8 +449,8 @@ module TypeInference =
             let ne = freshEffectVar fresh
             let np = freshPermVar fresh
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq rest
-            let o = typeValueSeq (DotSeq.ind (mkRecordValueType (TEmptyRow primFieldKind) (freshShareVar fresh)) rest)
+            let i = typeSeq rest
+            let o = typeSeq (DotSeq.ind (mkRecordValueType (TEmptyRow primFieldKind) (freshShareVar fresh)) rest)
             (unqualType (mkExpressionType ne np totalAttr i o), [], [Syntax.ERecordLiteral []])
         | Syntax.ERecordLiteral exp ->
             // the splat expression in a record literal must put a record on top of the stack
@@ -460,7 +460,7 @@ module TypeInference =
             let nr = freshFieldVar fresh
             let recVal = mkRecordValueType nr (freshShareVar fresh)
             let rest = freshSequenceVar fresh
-            let io = typeValueSeq (DotSeq.ind recVal rest)
+            let io = typeSeq (DotSeq.ind recVal rest)
             let verifyRecTop = unqualType (mkExpressionType ne np totalAttr io io)
             let (infVer, constrsVer) = composeWordTypes infExp verifyRecTop
             infVer, List.append constrsExp constrsVer, [Syntax.ERecordLiteral expExpand]
@@ -473,8 +473,8 @@ module TypeInference =
             let ns = freshShareVar fresh
             let recVal = mkRecordValueType recRow ns
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq (DotSeq.ind fieldVal (DotSeq.ind (mkRecordValueType nr ns) rest))
-            let o = typeValueSeq (DotSeq.ind recVal rest)
+            let i = typeSeq (DotSeq.ind fieldVal (DotSeq.ind (mkRecordValueType nr ns) rest))
+            let o = typeSeq (DotSeq.ind recVal rest)
             (unqualType (mkExpressionType ne np totalAttr i o), [], [Syntax.EExtension name])
         | Syntax.ESelect (false, name) ->
             // false = don't leave the record on the stack, just pop it. Makes selecting shared data
@@ -486,8 +486,8 @@ module TypeInference =
             let nr = freshFieldVar fresh
             let ns = freshShareVar fresh
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq (DotSeq.ind (mkRecordValueType (mkFieldRowExtend name.Name fieldVal nr) (typeOr rs ns)) rest)
-            let o = typeValueSeq (DotSeq.ind fieldVal rest)
+            let i = typeSeq (DotSeq.ind (mkRecordValueType (mkFieldRowExtend name.Name fieldVal nr) (typeOr rs ns)) rest)
+            let o = typeSeq (DotSeq.ind fieldVal rest)
             (unqualType (mkExpressionType ne np totalAttr i o), [], [Syntax.ESelect (false, name)])
         | Syntax.ESelect (true, name) ->
             // true = leave the record on the stack while selecting shared data out of it. Makes it easier
@@ -498,8 +498,8 @@ module TypeInference =
             let nr = freshFieldVar fresh
             let recVal = mkRecordValueType (mkFieldRowExtend name.Name fieldVal nr) (freshShareVar fresh)
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq (DotSeq.ind recVal rest)
-            let o = typeValueSeq (DotSeq.ind fieldVal (DotSeq.ind recVal rest))
+            let i = typeSeq (DotSeq.ind recVal rest)
+            let o = typeSeq (DotSeq.ind fieldVal (DotSeq.ind recVal rest))
             (unqualType (mkExpressionType ne np totalAttr i o), [], [Syntax.ESelect (true, name)])
         | Syntax.EVariantLiteral (name, exp) ->
             let (infExp, constrsExp, expExpand) = inferExpr fresh env exp
@@ -508,8 +508,8 @@ module TypeInference =
             let fieldVal = freshValueVar fresh
             let nr = freshFieldVar fresh
             let rest = freshSequenceVar fresh
-            let i = typeValueSeq (DotSeq.ind fieldVal rest)
-            let o = typeValueSeq (DotSeq.ind (mkVariantValueType (mkFieldRowExtend name.Name fieldVal nr) (freshShareVar fresh)) rest)
+            let i = typeSeq (DotSeq.ind fieldVal rest)
+            let o = typeSeq (DotSeq.ind (mkVariantValueType (mkFieldRowExtend name.Name fieldVal nr) (freshShareVar fresh)) rest)
             let varLit = unqualType (mkExpressionType ne np totalAttr i o)
             let varInf, varConstrs = composeWordTypes infExp varLit
             varInf, List.append constrsExp varConstrs, [Syntax.EVariantLiteral (name, expExpand)]
@@ -597,12 +597,12 @@ module TypeInference =
 
         | Syntax.EDo ->
             let irest = freshSequenceVar fresh
-            let i = typeValueSeq irest
-            let o = typeValueSeq (freshSequenceVar fresh)
+            let i = typeSeq irest
+            let o = typeSeq (freshSequenceVar fresh)
             let s = freshShareVar fresh
             let (e, p, t) = freshFunctionAttributes fresh
             let called = mkFunctionValueType e p t i o s
-            let caller = mkFunctionValueType e p t (typeValueSeq (DotSeq.ind called irest)) o sharedAttr
+            let caller = mkFunctionValueType e p t (typeSeq (DotSeq.ind called irest)) o sharedAttr
             (unqualType caller, [], [Syntax.EDo])
         | Syntax.EIdentifier id ->
             instantiateAndAddPlaceholders fresh env id.Name.Name word
@@ -665,13 +665,13 @@ module TypeInference =
             let (e, p, t, i, _) = functionValueTypeComponents fnTy
             let outs = functionValueTypeOuts fnTy
             let consO = DotSeq.ind aggResTy outs
-            mkFunctionValueType e p t i (typeValueSeq consO) (valueTypeSharing fnTy)
+            mkFunctionValueType e p t i (typeSeq consO) (valueTypeSharing fnTy)
         | Syntax.FForList ->
             let aggResTy = mkListType resValType (freshShareVar fresh)
             let (e, p, t, i, _) = functionValueTypeComponents fnTy
             let outs = functionValueTypeOuts fnTy
             let consO = DotSeq.ind aggResTy outs
-            mkFunctionValueType e p t i (typeValueSeq consO) (valueTypeSharing fnTy)
+            mkFunctionValueType e p t i (typeSeq consO) (valueTypeSharing fnTy)
         | Syntax.FForIterator ->
             let aggResTy = typeApp primIterCtor resValType
             let (_, p, t, i, o) = functionValueTypeComponents fnTy
@@ -683,7 +683,7 @@ module TypeInference =
             let (e, p, t, i, _) = functionValueTypeComponents fnTy
             let outs = functionValueTypeOuts fnTy
             let consO = DotSeq.ind aggResTy outs
-            mkFunctionValueType e p t i (typeValueSeq consO) (valueTypeSharing fnTy)
+            mkFunctionValueType e p t i (typeSeq consO) (valueTypeSharing fnTy)
 
     and inferForComprehension fresh env resTypes assigns body =
         let varsAndTys, constrsInf, assignExpand = List.map (inferForAssign fresh env) assigns |> List.unzip3
@@ -840,8 +840,8 @@ module TypeInference =
         let hdlResult = List.fold (fun s t -> DotSeq.ind t s) DotSeq.SEnd hdlResultTys
                 
         let resultConstrs = 
-            [typeEqConstraint (typeValueSeq (functionValueTypeOuts (qualTypeHead aftTy))) (typeValueSeq hdlResult);
-             typeEqConstraint (typeValueSeq (functionValueTypeIns (qualTypeHead effHdldTy))) (typeValueSeq DotSeq.SEnd)]
+            [typeEqConstraint (typeSeq (functionValueTypeOuts (qualTypeHead aftTy))) (typeSeq hdlResult);
+             typeEqConstraint (typeSeq (functionValueTypeIns (qualTypeHead effHdldTy))) (typeSeq DotSeq.SEnd)]
 
         let (hdlrTys, hdlrCnstrs, hdlrPlcs) =
             List.zip handlers hdlrTypeTemplates
@@ -885,12 +885,12 @@ module TypeInference =
 
         let outCnstr =
             typeEqConstraint
-                (typeValueSeq resultTy)
-                (typeValueSeq (functionValueTypeOuts (qualTypeHead hdlrTy)))
+                (typeSeq resultTy)
+                (typeSeq (functionValueTypeOuts (qualTypeHead hdlrTy)))
         let inCnstr =
             typeEqConstraint
-                (typeValueSeq (functionValueTypeIns (qualTypeHead templateTy) |> removeSeqPoly))
-                (typeValueSeq (functionValueTypeIns (qualTypeHead hdlrTy)))
+                (typeSeq (functionValueTypeIns (qualTypeHead templateTy) |> removeSeqPoly))
+                (typeSeq (functionValueTypeIns (qualTypeHead hdlrTy)))
         hdlrTy, List.concat [[outCnstr; inCnstr]; bCnstrs], { hdlr with Body = bPlc }
     and inferMatchClause fresh env clause =
         let varTypes, constrsP, poppedTypes =
@@ -914,8 +914,8 @@ module TypeInference =
         let fieldVal = mkValueType (freshDataVar fresh) fs
         let nr = freshFieldVar fresh
         let rest = freshSequenceVar fresh
-        let i = typeValueSeq (DotSeq.ind (mkVariantValueType (mkFieldRowExtend clause.Tag.Name fieldVal nr) (typeOr fs caseShare)) rest)
-        let o = typeValueSeq (DotSeq.ind fieldVal rest)
+        let i = typeSeq (DotSeq.ind (mkVariantValueType (mkFieldRowExtend clause.Tag.Name fieldVal nr) (typeOr fs caseShare)) rest)
+        let o = typeSeq (DotSeq.ind fieldVal rest)
         let destruct = unqualType (mkExpressionType ne np totalAttr i o)
         let infDest, constrsDest = composeWordTypes destruct infBody
         infDest, List.append constrsBody constrsDest, { clause with Body = bodyExp }
@@ -942,7 +942,7 @@ module TypeInference =
                 let names = List.map fst sch.QuantifiedTypes
                 let subst = List.zip names [] |> Map.ofList
                 expandSynonyms fresh env (typeSubstSimplifyExn fresh subst sch.Body)
-        | TSeq (ts, k) -> TSeq (DotSeq.map (expandSynonyms fresh env) ts, k)
+        | TSeq ts -> typeSeq (DotSeq.map (expandSynonyms fresh env) ts)
         // TODO: should we handle abelian or boolean type expressions here?
         | _ -> ty
 
@@ -1043,10 +1043,10 @@ module TypeInference =
         assert (List.forall (fun t -> typeKindExn t = primValueKind) argTypes)
         assert (typeKindExn retType = primValueKind)
 
-        let tySeq = typeValueSeq (DotSeq.ofList componentsAndResult)
+        let tySeq = typeSeq (DotSeq.ofList componentsAndResult)
         let rest = freshSequenceVar fresh
-        let o = typeValueSeq (DotSeq.ind retType rest)
-        let i = typeValueSeq (DotSeq.append (DotSeq.ofList argTypes) rest)
+        let o = typeSeq (DotSeq.ind retType rest)
+        let i = typeSeq (DotSeq.append (DotSeq.ofList argTypes) rest)
         let e = freshEffectVar fresh
         let p = freshPermVar fresh
         let fn = mkExpressionType e p totalAttr i o
@@ -1124,7 +1124,7 @@ module TypeInference =
         let hdTys, kenv = List.mapFold (fun env (ty, k) -> kindAnnotateTypeWithConstraints fresh k env ty) env headWithKind
         let hdTys = List.map (expandSynonyms fresh env) hdTys
         let ctxtTys = DotSeq.map (kindAnnotateType fresh kenv >> expandSynonyms fresh env) context
-        let allParamTysInOne = typeValueSeq (DotSeq.append ctxtTys (DotSeq.ofList hdTys))
+        let allParamTysInOne = typeSeq (DotSeq.append ctxtTys (DotSeq.ofList hdTys))
         let freshSubst = freshTypeSubst fresh (typeFreeWithKinds allParamTysInOne)
         let freshHdTys = List.map (typeSubstSimplifyExn fresh freshSubst) hdTys
         let freshCtxtTys = DotSeq.map (typeSubstSimplifyExn fresh freshSubst) ctxtTys
@@ -1347,7 +1347,7 @@ module TypeInference =
             then failwith $"Inferred pattern expression for {p.Name.Name} contained variables not in the parameter list"
             let tsub, ksub = solveAll fresh infCs
             let normalized = valueTypeData (typeAndKindSubstExn fresh ksub tsub inferred)
-            let patTy = typeValueSeq (DotSeq.ofList (List.append [for (v, t) in infVs -> typeAndKindSubstExn fresh ksub tsub t] [normalized]))
+            let patTy = typeSeq (DotSeq.ofList (List.append [for (v, t) in infVs -> typeAndKindSubstExn fresh ksub tsub t] [normalized]))
             let patEnv = addPattern env p.Name.Name (schemeFromType patTy)
             inferDefs fresh patEnv ds (Syntax.DPattern p :: exps)
         | Syntax.DTypeSynonym s :: ds ->
@@ -1367,6 +1367,7 @@ module TypeInference =
             try
                 inferTop fresh env prog.Main
             with
+                | UnifyKindMismatchException (l, r) -> failwith $"Failed to infer type of main with kind mismatch: {l} ~ {r}"
                 | UnifySequenceMismatch (ls, rs) -> failwith $"Failed to infer type of main with sequence mismatch: {ls} ~ {rs}"
                 | ex -> failwith $"Failed to infer type of main with {ex}"
         if DotSeq.any (fun _ -> true) (qualTypeContext mType)

--- a/Boba.Compiler/TypeInference.fs
+++ b/Boba.Compiler/TypeInference.fs
@@ -840,8 +840,8 @@ module TypeInference =
         let hdlResult = List.fold (fun s t -> DotSeq.ind t s) DotSeq.SEnd hdlResultTys
                 
         let resultConstrs = 
-            [typeEqConstraint (TSeq (functionValueTypeOuts (qualTypeHead aftTy), primValueKind)) (TSeq (hdlResult, primValueKind));
-             typeEqConstraint (TSeq (functionValueTypeIns (qualTypeHead effHdldTy), primValueKind)) (TSeq (DotSeq.SEnd, primValueKind))]
+            [typeEqConstraint (typeValueSeq (functionValueTypeOuts (qualTypeHead aftTy))) (typeValueSeq hdlResult);
+             typeEqConstraint (typeValueSeq (functionValueTypeIns (qualTypeHead effHdldTy))) (typeValueSeq DotSeq.SEnd)]
 
         let (hdlrTys, hdlrCnstrs, hdlrPlcs) =
             List.zip handlers hdlrTypeTemplates
@@ -1124,7 +1124,7 @@ module TypeInference =
         let hdTys, kenv = List.mapFold (fun env (ty, k) -> kindAnnotateTypeWithConstraints fresh k env ty) env headWithKind
         let hdTys = List.map (expandSynonyms fresh env) hdTys
         let ctxtTys = DotSeq.map (kindAnnotateType fresh kenv >> expandSynonyms fresh env) context
-        let allParamTysInOne = TSeq (DotSeq.append ctxtTys (DotSeq.ofList hdTys), primValueKind)
+        let allParamTysInOne = typeValueSeq (DotSeq.append ctxtTys (DotSeq.ofList hdTys))
         let freshSubst = freshTypeSubst fresh (typeFreeWithKinds allParamTysInOne)
         let freshHdTys = List.map (typeSubstSimplifyExn fresh freshSubst) hdTys
         let freshCtxtTys = DotSeq.map (typeSubstSimplifyExn fresh freshSubst) ctxtTys

--- a/Boba.Core.Test/Boba.Core.Test.fsproj
+++ b/Boba.Core.Test/Boba.Core.Test.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="KindTests.fs" />
     <Compile Include="SubstitutionTests.fs" />
     <Compile Include="UnificationTests.fs" />
     <Compile Include="BooleanTests.fs" />

--- a/Boba.Core.Test/Boba.Core.Test.fsproj
+++ b/Boba.Core.Test/Boba.Core.Test.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="SubstitutionTests.fs" />
     <Compile Include="UnificationTests.fs" />
     <Compile Include="BooleanTests.fs" />
     <Compile Include="QuineMcCluskeyTest.fs" />

--- a/Boba.Core.Test/KindTests.fs
+++ b/Boba.Core.Test/KindTests.fs
@@ -1,0 +1,32 @@
+module KindTests
+
+open Xunit
+open Boba.Core.Kinds
+
+[<Fact>]
+let ``No top kind equality`` () =
+    Assert.True(
+        kindEq
+            (karrow (kseq (krow (kvar "s"))) (krow (kseq (KUser ("K", KUSyntactic)))))
+            (karrow (kseq (krow (kvar "s"))) (krow (kseq (KUser ("K", KUSyntactic))))))
+
+[<Fact>]
+let ``Top kind equality`` () =
+    Assert.True(kindEq KAny (kvar "s"))
+    Assert.True(kindEq (kvar "s") KAny)
+    Assert.True(
+        kindEq
+            (karrow (kseq (krow KAny)) (krow (kseq (KUser ("K", KUSyntactic)))))
+            (karrow (kseq (krow (kvar "s"))) (krow (kseq KAny))))
+
+[<Fact>]
+let ``Kind apply respects _ supertype in arrow`` () =
+    Assert.StrictEqual(kvar "o", applyKindExn (karrow (kvar "i") (kvar "o")) (kvar "i"))
+    Assert.StrictEqual(kvar "o", applyKindExn (karrow KAny (kvar "o")) (kvar "i"))
+    Assert.StrictEqual(kvar "o", applyKindExn (karrow (kseq KAny) (kvar "o")) (kseq (kvar "i")))
+
+[<Fact>]
+let ``Kind apply respects _ supertype in argument`` () =
+    Assert.StrictEqual(kvar "o", applyKindExn (karrow (krow (kvar "i")) (kvar "o")) (krow (kvar "i")))
+    Assert.StrictEqual(kvar "o", applyKindExn (karrow (kvar "i") (kvar "o")) KAny)
+    Assert.StrictEqual(kvar "o", applyKindExn (karrow (kseq (kvar "i")) (kvar "o")) (kseq KAny))

--- a/Boba.Core.Test/KindTests.fs
+++ b/Boba.Core.Test/KindTests.fs
@@ -20,6 +20,27 @@ let ``Top kind equality`` () =
             (karrow (kseq (krow (kvar "s"))) (krow (kseq KAny))))
 
 [<Fact>]
+let ``Can apply kind respects _ supertype in arrow`` () =
+    Assert.True(canApplyKind (karrow (kvar "i") (kvar "o")) (kvar "i"))
+    Assert.True(canApplyKind (karrow KAny (kvar "o")) (kvar "i"))
+    Assert.True(canApplyKind (karrow (kseq KAny) (kvar "o")) (kseq (kvar "i")))
+
+[<Fact>]
+let ``Can apply kind respects _ supertype in argument`` () =
+    Assert.True(canApplyKind (karrow (krow (kvar "i")) (kvar "o")) (krow (kvar "i")))
+    Assert.True(canApplyKind (karrow (kvar "i") (kvar "o")) KAny)
+    Assert.True(canApplyKind (karrow (kseq (kvar "i")) (kvar "o")) (kseq KAny))
+    Assert.True(canApplyKind (karrow (kseq (kseq (kvar "s"))) (kvar "o")) (kseq KAny))
+
+[<Fact>]
+let ``Can apply fails when not arrow and arg not equal input`` () =
+    Assert.False(canApplyKind (kvar "s") (kvar "s"))
+    Assert.False(canApplyKind (kseq (kvar "s")) KAny)
+    Assert.False(canApplyKind KAny KAny)
+    Assert.False(canApplyKind (karrow (kvar "i") (kvar "o")) (kvar "x"))
+    Assert.False(canApplyKind (karrow (kseq (kseq (kvar "s"))) (kvar "o")) (kseq (kvar "s")))
+
+[<Fact>]
 let ``Kind apply respects _ supertype in arrow`` () =
     Assert.StrictEqual(kvar "o", applyKindExn (karrow (kvar "i") (kvar "o")) (kvar "i"))
     Assert.StrictEqual(kvar "o", applyKindExn (karrow KAny (kvar "o")) (kvar "i"))
@@ -30,3 +51,10 @@ let ``Kind apply respects _ supertype in argument`` () =
     Assert.StrictEqual(kvar "o", applyKindExn (karrow (krow (kvar "i")) (kvar "o")) (krow (kvar "i")))
     Assert.StrictEqual(kvar "o", applyKindExn (karrow (kvar "i") (kvar "o")) KAny)
     Assert.StrictEqual(kvar "o", applyKindExn (karrow (kseq (kvar "i")) (kvar "o")) (kseq KAny))
+
+[<Fact>]
+let ``Kind apply throws when not arrow and arg not equal input`` () =
+    Assert.Throws<KindApplyNotArrow>(fun () -> applyKindExn (kvar "s") (kvar "s") |> ignore)
+    Assert.Throws<KindApplyNotArrow>(fun () -> applyKindExn (kseq (kvar "s")) KAny |> ignore)
+    Assert.Throws<KindApplyNotArrow>(fun () -> applyKindExn KAny KAny |> ignore)
+    Assert.Throws<KindApplyArgMismatch>(fun () -> applyKindExn (karrow (kvar "i") (kvar "o")) (kvar "x") |> ignore)

--- a/Boba.Core.Test/SubstitutionTests.fs
+++ b/Boba.Core.Test/SubstitutionTests.fs
@@ -15,17 +15,37 @@ let ``Kind of sequence`` () =
     Assert.StrictEqual(kseq primValueKind, typeKindExn seq2)
 
 [<Fact>]
+let ``Kind of empty sequence`` () =
+    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd primValueKind))
+    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd primDataKind))
+    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd primSharingKind))
+
+[<Fact>]
 let ``Invalid kind of sequence`` () =
     let invalidSeq = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primDataKind) SEnd)) primValueKind
     Assert.Throws<KindNotExpected>(fun () -> typeKindExn invalidSeq |> ignore)
 
 [<Fact>]
+let ``Compute value kind`` () =
+    let valType = mkValueType (typeVar "d" primDataKind) (typeVar "s" primSharingKind)
+    Assert.StrictEqual(primValueKind, typeKindExn valType)
+
+[<Fact>]
+let ``Compute constraint kind`` () =
+    let qual = qualType (ind (typeCon "C" primConstraintKind) SEnd) (typeVar "v" primValueKind)
+    Assert.StrictEqual(primValueKind, typeKindExn qual)
+
+[<Fact>]
 let ``Compute fn kind`` () =
     let fn =
-        mkFunctionType
-            (typeVar "e" (KRow primEffectKind))
-            (typeVar "p" (KRow primPermissionKind))
-            (typeVar "t" primTotalityKind)
-            (typeValueSeq (dot (typeVar "z" primValueKind) SEnd))
-            (typeValueSeq (dot (typeVar "z" primValueKind) SEnd))
-    Assert.StrictEqual(primDataKind, typeKindExn fn)
+        try
+            typeKindExn 
+                (mkFunctionType
+                (typeVar "e" (krow primEffectKind))
+                (typeVar "p" (krow primPermissionKind))
+                (typeVar "t" primTotalityKind)
+                (typeValueSeq (dot (typeVar "z" primValueKind) SEnd))
+                (typeValueSeq (dot (typeVar "z" primValueKind) SEnd)))
+        with
+        | KindApplyArgMismatch (l, r) -> karrow l r
+    Assert.StrictEqual(primDataKind, fn)

--- a/Boba.Core.Test/SubstitutionTests.fs
+++ b/Boba.Core.Test/SubstitutionTests.fs
@@ -5,6 +5,7 @@ open Boba.Core.DotSeq
 open Boba.Core.Fresh
 open Boba.Core.Kinds
 open Boba.Core.Types
+open Boba.Core.TypeBuilder
 
 [<Fact>]
 let ``Kind of sequence`` () =
@@ -17,3 +18,14 @@ let ``Kind of sequence`` () =
 let ``Invalid kind of sequence`` () =
     let invalidSeq = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primDataKind) SEnd)) primValueKind
     Assert.Throws<KindNotExpected>(fun () -> typeKindExn invalidSeq |> ignore)
+
+[<Fact>]
+let ``Compute fn kind`` () =
+    let fn =
+        mkFunctionType
+            (typeVar "e" (KRow primEffectKind))
+            (typeVar "p" (KRow primPermissionKind))
+            (typeVar "t" primTotalityKind)
+            (typeValueSeq (dot (typeVar "z" primValueKind) SEnd))
+            (typeValueSeq (dot (typeVar "z" primValueKind) SEnd))
+    Assert.StrictEqual(primDataKind, typeKindExn fn)

--- a/Boba.Core.Test/SubstitutionTests.fs
+++ b/Boba.Core.Test/SubstitutionTests.fs
@@ -9,20 +9,20 @@ open Boba.Core.TypeBuilder
 
 [<Fact>]
 let ``Kind of sequence`` () =
-    let seq1 = typeSeq (ind (typeCon "s" primValueKind) SEnd) primValueKind
-    let seq2 = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primValueKind) SEnd)) primValueKind
+    let seq1 = typeSeq (ind (typeCon "s" primValueKind) SEnd)
+    let seq2 = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primValueKind) SEnd))
     Assert.StrictEqual(kseq primValueKind, typeKindExn seq1)
     Assert.StrictEqual(kseq primValueKind, typeKindExn seq2)
 
 [<Fact>]
 let ``Kind of empty sequence`` () =
-    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd primValueKind))
-    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd primDataKind))
-    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd primSharingKind))
+    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd))
+    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd))
+    Assert.StrictEqual(kseq KAny, typeKindExn (typeSeq SEnd))
 
 [<Fact>]
 let ``Invalid kind of sequence`` () =
-    let invalidSeq = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primDataKind) SEnd)) primValueKind
+    let invalidSeq = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primDataKind) SEnd))
     Assert.Throws<KindNotExpected>(fun () -> typeKindExn invalidSeq |> ignore)
 
 [<Fact>]
@@ -44,8 +44,8 @@ let ``Compute fn kind`` () =
                 (typeVar "e" (krow primEffectKind))
                 (typeVar "p" (krow primPermissionKind))
                 (typeVar "t" primTotalityKind)
-                (typeValueSeq (dot (typeVar "z" primValueKind) SEnd))
-                (typeValueSeq (dot (typeVar "z" primValueKind) SEnd)))
+                (typeSeq (dot (typeVar "z" primValueKind) SEnd))
+                (typeSeq (dot (typeVar "z" primValueKind) SEnd)))
         with
         | KindApplyArgMismatch (l, r) -> karrow l r
     Assert.StrictEqual(primDataKind, fn)

--- a/Boba.Core.Test/SubstitutionTests.fs
+++ b/Boba.Core.Test/SubstitutionTests.fs
@@ -1,0 +1,19 @@
+module SubstitutionTests
+
+open Xunit
+open Boba.Core.DotSeq
+open Boba.Core.Fresh
+open Boba.Core.Kinds
+open Boba.Core.Types
+
+[<Fact>]
+let ``Kind of sequence`` () =
+    let seq1 = typeSeq (ind (typeCon "s" primValueKind) SEnd) primValueKind
+    let seq2 = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primValueKind) SEnd)) primValueKind
+    Assert.StrictEqual(kseq primValueKind, typeKindExn seq1)
+    Assert.StrictEqual(kseq primValueKind, typeKindExn seq2)
+
+[<Fact>]
+let ``Invalid kind of sequence`` () =
+    let invalidSeq = typeSeq (ind (typeCon "s" primValueKind) (ind (typeCon "t" primDataKind) SEnd)) primValueKind
+    Assert.Throws<KindNotExpected>(fun () -> typeKindExn invalidSeq |> ignore)

--- a/Boba.Core.Test/UnificationTests.fs
+++ b/Boba.Core.Test/UnificationTests.fs
@@ -55,13 +55,13 @@ let ``Unify succeed: (a B) ~ (c d)`` () =
 let ``Unify succeed: b B a ... ~ c c e d ...`` () =
     let tsub, ksub =
         typeUnifyExn (new SimpleFresh(0))
-            (TSeq (SInd (typeVar "b" primValueKind, SInd (typeCon "B" primValueKind, SDot (typeVar "a" primValueKind, SEnd))), primValueKind))
-            (TSeq (SInd (typeVar "c" primValueKind, SInd (typeVar "c" primValueKind, SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd)))), primValueKind))
+            (typeValueSeq (SInd (typeVar "b" primValueKind, SInd (typeCon "B" primValueKind, SDot (typeVar "a" primValueKind, SEnd)))))
+            (typeValueSeq (SInd (typeVar "c" primValueKind, SInd (typeVar "c" primValueKind, SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd))))))
     Assert.StrictEqual(
         Map.empty
             .Add("b", typeCon "B" primValueKind)
             .Add("c", typeCon "B" primValueKind)
-            .Add("a", TSeq (SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd)), primValueKind))
+            .Add("a", typeValueSeq (SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd))))
             .Add("a0", typeVar "e" primValueKind)
             .Add("a1", typeVar "d" primValueKind),
         tsub)
@@ -76,19 +76,19 @@ let ``Unify succeed: (V a b) ~ (V c d)...`` () =
             (typeValueSeq (dot (typeApp (typeApp vcon (typeVar "c" primDataKind)) (typeVar "d" primSharingKind)) SEnd))
     Assert.StrictEqual(
         Map.empty
-            .Add("c", TSeq (ind (typeVar "a" primDataKind) SEnd, primDataKind))
-            .Add("d", TSeq (ind (typeVar "b" primSharingKind) SEnd, primSharingKind))
+            .Add("c", typeSeq (ind (typeVar "a" primDataKind) SEnd) primDataKind)
+            .Add("d", typeSeq (ind (typeVar "b" primSharingKind) SEnd) primSharingKind)
             .Add("c0", typeVar "a" primDataKind)
-            .Add("c1", TSeq (SEnd, primDataKind))
+            .Add("c1", typeSeq SEnd primDataKind)
             .Add("d2", typeVar "b" primSharingKind)
-            .Add("d3", TSeq (SEnd, primSharingKind)),
+            .Add("d3", typeSeq SEnd primSharingKind),
         tsub)
     Assert.StrictEqual(Map.empty, ksub)
 
 [<Fact>]
 let ``Unify fail: a ... ~ b a...`` () =
     Assert.Throws<UnifyTypeOccursCheckFailure>(fun () ->
-        typeUnifyExn (new SimpleFresh(0)) (TSeq (SDot (typeVar "a" primValueKind, SEnd), primValueKind)) (TSeq (SInd (typeVar "b" primValueKind, SDot (typeVar "a" primValueKind, SEnd)), primValueKind)) |> ignore)
+        typeUnifyExn (new SimpleFresh(0)) (typeValueSeq (SDot (typeVar "a" primValueKind, SEnd))) (typeValueSeq (SInd (typeVar "b" primValueKind, SDot (typeVar "a" primValueKind, SEnd)))) |> ignore)
 
 [<Fact>]
 let ``Unify fail: one: a, b... ~ two: c, b...`` () =

--- a/Boba.Core.Test/UnificationTests.fs
+++ b/Boba.Core.Test/UnificationTests.fs
@@ -55,13 +55,13 @@ let ``Unify succeed: (a B) ~ (c d)`` () =
 let ``Unify succeed: b B a ... ~ c c e d ...`` () =
     let tsub, ksub =
         typeUnifyExn (new SimpleFresh(0))
-            (typeValueSeq (SInd (typeVar "b" primValueKind, SInd (typeCon "B" primValueKind, SDot (typeVar "a" primValueKind, SEnd)))))
-            (typeValueSeq (SInd (typeVar "c" primValueKind, SInd (typeVar "c" primValueKind, SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd))))))
+            (typeSeq (SInd (typeVar "b" primValueKind, SInd (typeCon "B" primValueKind, SDot (typeVar "a" primValueKind, SEnd)))))
+            (typeSeq (SInd (typeVar "c" primValueKind, SInd (typeVar "c" primValueKind, SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd))))))
     Assert.StrictEqual(
         Map.empty
             .Add("b", typeCon "B" primValueKind)
             .Add("c", typeCon "B" primValueKind)
-            .Add("a", typeValueSeq (SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd))))
+            .Add("a", typeSeq (SInd (typeVar "e" primValueKind, SDot (typeVar "d" primValueKind, SEnd))))
             .Add("a0", typeVar "e" primValueKind)
             .Add("a1", typeVar "d" primValueKind),
         tsub)
@@ -72,23 +72,23 @@ let ``Unify succeed: (V a b) ~ (V c d)...`` () =
     let vcon = typeCon "V" (karrow primDataKind (karrow primSharingKind primValueKind))
     let tsub, ksub =
         typeUnifyExn (new SimpleFresh(0))
-            (typeValueSeq (ind (typeApp (typeApp vcon (typeVar "a" primDataKind)) (typeVar "b" primSharingKind)) SEnd))
-            (typeValueSeq (dot (typeApp (typeApp vcon (typeVar "c" primDataKind)) (typeVar "d" primSharingKind)) SEnd))
+            (typeSeq (ind (typeApp (typeApp vcon (typeVar "a" primDataKind)) (typeVar "b" primSharingKind)) SEnd))
+            (typeSeq (dot (typeApp (typeApp vcon (typeVar "c" primDataKind)) (typeVar "d" primSharingKind)) SEnd))
     Assert.StrictEqual(
         Map.empty
-            .Add("c", typeSeq (ind (typeVar "a" primDataKind) SEnd) primDataKind)
-            .Add("d", typeSeq (ind (typeVar "b" primSharingKind) SEnd) primSharingKind)
+            .Add("c", typeSeq (ind (typeVar "a" primDataKind) SEnd))
+            .Add("d", typeSeq (ind (typeVar "b" primSharingKind) SEnd))
             .Add("c0", typeVar "a" primDataKind)
-            .Add("c1", typeSeq SEnd primDataKind)
+            .Add("c1", typeSeq SEnd)
             .Add("d2", typeVar "b" primSharingKind)
-            .Add("d3", typeSeq SEnd primSharingKind),
+            .Add("d3", typeSeq SEnd),
         tsub)
     Assert.StrictEqual(Map.empty, ksub)
 
 [<Fact>]
 let ``Unify fail: a ... ~ b a...`` () =
     Assert.Throws<UnifyTypeOccursCheckFailure>(fun () ->
-        typeUnifyExn (new SimpleFresh(0)) (typeValueSeq (SDot (typeVar "a" primValueKind, SEnd))) (typeValueSeq (SInd (typeVar "b" primValueKind, SDot (typeVar "a" primValueKind, SEnd)))) |> ignore)
+        typeUnifyExn (new SimpleFresh(0)) (typeSeq (SDot (typeVar "a" primValueKind, SEnd))) (typeSeq (SInd (typeVar "b" primValueKind, SDot (typeVar "a" primValueKind, SEnd)))) |> ignore)
 
 [<Fact>]
 let ``Unify fail: one: a, b... ~ two: c, b...`` () =

--- a/Boba.Core/CHR.fs
+++ b/Boba.Core/CHR.fs
@@ -122,7 +122,7 @@ module CHR =
             if isDotted
             then
                 match subbed with
-                | TSeq (ts, k) -> { store with Predicates = DotSeq.foldDotted (fun d ps r -> if d then Set.add (TSeq (DotSeq.dot r DotSeq.SEnd, k)) ps else Set.add r ps) store.Predicates ts }
+                | TSeq ts -> { store with Predicates = DotSeq.foldDotted (fun d ps r -> if d then Set.add (typeSeq (DotSeq.dot r DotSeq.SEnd)) ps else Set.add r ps) store.Predicates ts }
                 | t -> { store with Predicates = Set.add t store.Predicates }
             else { store with Predicates = Set.add subbed store.Predicates }
         | CEquality eqn -> { store with Equalities = (constraintSubstExn fresh Map.empty subst eqn) :: store.Equalities }

--- a/Boba.Core/Kinds.fs
+++ b/Boba.Core/Kinds.fs
@@ -124,9 +124,16 @@ module Kinds =
         | KRow lk, KRow rk -> kindEq lk rk
         | KVar lv, KVar rv -> lv = rv
         | _, _ -> false
+    
+    /// Given an arrow kind `(k1 -> k2)`, return whether the argument kind `k3` is equal to `k1`.
+    /// If the arrow kind is not actually an arrow, returns false.
+    let canApplyKind arrKind argKind =
+        match arrKind with
+        | KArrow (arg, _) -> kindEq arg argKind
+        | _ -> false
 
-    /// Given an arrow kind (k1 -> k2), if the argument kind k3 is equal to k1, return k2.
-    /// If k1 <> k3, or if arrKind is not actually an arrow kind, raises an exception.
+    /// Given an arrow kind `(k1 -> k2)`, if the argument kind `k3` is equal to `k1`, return `k2`.
+    /// If `k1` doesn't equal `k3`, or if arrKind is not actually an arrow kind, raises an exception.
     let applyKindExn arrKind argKind =
         match arrKind with
         | KArrow (input, output) when kindEq input argKind -> output

--- a/Boba.Core/Matching.fs
+++ b/Boba.Core/Matching.fs
@@ -43,7 +43,7 @@ module Matching =
             let freshInd = fresh.Fresh x
             let freshSeq = fresh.Fresh x
             let sub = genSplitSub fresh xs
-            Map.add x (TSeq (DotSeq.SInd (typeVar freshInd k, (DotSeq.SDot (typeVar freshSeq k, DotSeq.SEnd))), k)) sub
+            Map.add x (TSeq (DotSeq.SInd (typeVar freshInd k, (DotSeq.SDot (typeVar freshSeq k, DotSeq.SEnd))))) sub
 
 
     // One-way matching of types
@@ -95,7 +95,7 @@ module Matching =
             | None -> raise (MatchAbelianMismatch (l, r))
         | _ when isKindExtensibleRow (typeKindExn l) || isKindExtensibleRow (typeKindExn r) ->
             matchRow fresh (typeToRow l) (typeToRow r)
-        | TSeq (ls, lk), TSeq (rs, rk) when kindEq lk rk ->
+        | TSeq ls, TSeq rs when kindEq (typeKindExn l) (typeKindExn r) ->
             typeMatchSeqExn fresh ls rs
         | TSeq _, TSeq _ ->
             raise (MatchNonValueSequence (l, r))
@@ -111,18 +111,18 @@ module Matching =
             Map.empty
         | DotSeq.SInd (li, lss), DotSeq.SInd (ri, rss) ->
             let lu = typeMatchExn fresh li ri
-            let ru = typeMatchExn fresh (typeSubstSimplifyExn fresh lu (typeValueSeq lss)) (typeSubstSimplifyExn fresh lu (typeValueSeq rss))
+            let ru = typeMatchExn fresh (typeSubstSimplifyExn fresh lu (typeSeq lss)) (typeSubstSimplifyExn fresh lu (typeSeq rss))
             mergeSubstExn fresh ru lu
         | DotSeq.SDot (ld, DotSeq.SEnd), DotSeq.SDot (rd, DotSeq.SEnd) ->
             typeMatchExn fresh ld rd
         | DotSeq.SDot (li, DotSeq.SEnd), DotSeq.SEnd ->
-            [for (v, k) in List.ofSeq (typeFreeWithKinds li) do (v, typeSeq DotSeq.SEnd k)] |> Map.ofList
+            [for (v, k) in List.ofSeq (typeFreeWithKinds li) do (v, typeSeq DotSeq.SEnd)] |> Map.ofList
         | DotSeq.SDot (li, DotSeq.SEnd), DotSeq.SInd (ri, rs) ->
             let freshVars = typeFreeWithKinds li |> List.ofSeq |> genSplitSub fresh
             let extended =
                 typeMatchExn fresh
-                    (typeSubstSimplifyExn fresh freshVars (typeValueSeq (DotSeq.SDot (li, DotSeq.SEnd))))
-                    (typeValueSeq (DotSeq.SInd (ri, rs)))
+                    (typeSubstSimplifyExn fresh freshVars (typeSeq (DotSeq.SDot (li, DotSeq.SEnd))))
+                    (typeSeq (DotSeq.SInd (ri, rs)))
             mergeSubstExn fresh extended freshVars
         | _ ->
             raise (MatchSequenceMismatch (ls, rs))
@@ -185,7 +185,7 @@ module Matching =
             | None -> raise (MatchAbelianMismatch (l, r))
         | _ when isKindExtensibleRow (typeKindExn l) || isKindExtensibleRow (typeKindExn r) ->
             strictMatchRow fresh (typeToRow l) (typeToRow r)
-        | TSeq (ls, lk), TSeq (rs, rk) when lk = rk ->
+        | TSeq ls, TSeq rs when typeKindExn (TSeq ls) = typeKindExn (TSeq rs) ->
             strictTypeMatchSeqExn fresh ls rs
         | TSeq _, TSeq _ ->
             raise (MatchNonValueSequence (l, r))
@@ -201,12 +201,12 @@ module Matching =
             Map.empty
         | DotSeq.SInd (li, lss), DotSeq.SInd (ri, rss) ->
             let lu = strictTypeMatchExn fresh li ri
-            let ru = strictTypeMatchExn fresh (typeSubstSimplifyExn fresh lu (typeValueSeq lss)) (typeSubstSimplifyExn fresh lu (typeValueSeq rss))
+            let ru = strictTypeMatchExn fresh (typeSubstSimplifyExn fresh lu (typeSeq lss)) (typeSubstSimplifyExn fresh lu (typeSeq rss))
             mergeSubstExn fresh ru lu
         | DotSeq.SDot (ld, DotSeq.SEnd), DotSeq.SDot (rd, DotSeq.SEnd) ->
             strictTypeMatchExn fresh ld rd
         | DotSeq.SDot (li, DotSeq.SEnd), DotSeq.SEnd ->
-            [for (v, k) in List.ofSeq (typeFreeWithKinds li) do (v, typeSeq DotSeq.SEnd k)] |> Map.ofList
+            [for (v, k) in List.ofSeq (typeFreeWithKinds li) do (v, typeSeq DotSeq.SEnd)] |> Map.ofList
         | _ ->
             raise (MatchSequenceMismatch (ls, rs))
     and strictMatchRow fresh leftRow rightRow =

--- a/Boba.Core/TypeBuilder.fs
+++ b/Boba.Core/TypeBuilder.fs
@@ -142,19 +142,8 @@ module TypeBuilder =
     /// 4) The input value sequence required for the expression to complete (4th, kind Seq Value)
     /// 5) The output value sequence returned when the expression completes (outer, kind Seq Value)
     /// 
-    /// For the other three attributes, a couple special conditions apply:
-    /// 1) The trust attribute is almost always Trusted (True), since user input can never contruct
-    ///    a function value. While closures may have access to Untrusted data, that does not mean
-    ///    that the function itself is Untrusted. The only time a function type is Untrusted is when
-    ///    a module is imported as untrusted or when a function value comes from a dynamically loaded library.
-    /// 2) The clearance attribute is dependent on the values the function closure contains. This is to
-    ///    support eventual remote code execution on potentially untrusted machines, i.e. sending a function
-    ///    to another machine to be computed and receiving the result. In such a case, we may not want to
-    ///    expose sensitive information to the remote machine, but the closure may store sensitive data
-    ///    in it's captured scope. So, a closure that refers to any variable marked secret will also be
-    ///    be marked secret.
-    /// 3) The sharing attribute, unlike trust, is dependent on the values the function closure contains.
-    ///    So a closure value that refers to a value variable marked as unique must also be marked as unique.
+    /// The sharing attribute is dependent on the values the function closure contains.
+    /// A closure value that refers to a value variable marked as unique must also be marked as unique.
     let mkFunctionType effs perms total ins outs =
         typeApp (typeApp (typeApp (typeApp (typeApp primFuctionCtor effs) perms) total) ins) outs
     

--- a/Boba.Core/TypeBuilder.fs
+++ b/Boba.Core/TypeBuilder.fs
@@ -180,19 +180,19 @@ module TypeBuilder =
 
     let functionValueTypeIns fnTy =
         match functionValueTypeComponents fnTy with
-        | (_, _, _, TSeq (is, _), _) -> is
+        | (_, _, _, TSeq is, _) -> is
     
     let functionValueTypeOuts fnTy =
         match functionValueTypeComponents fnTy with
-        | (_, _, _, _, TSeq (os, _)) -> os
+        | (_, _, _, _, TSeq os) -> os
 
     let updateFunctionValueTypeEffect fnTy eff =
         let (_, p, t, i, o) = functionValueTypeComponents fnTy
         updateValueTypeData fnTy (mkFunctionType eff p t i o)
     
     let removeStackPolyFunctionType fnTy =
-        let e, p, t, TSeq (i, ik), TSeq (o, ok) = functionValueTypeComponents fnTy
-        mkFunctionType e p t (TSeq (removeSeqPoly i, ik)) (TSeq (removeSeqPoly o, ok))
+        let e, p, t, TSeq i, TSeq o = functionValueTypeComponents fnTy
+        mkFunctionType e p t (typeSeq (removeSeqPoly i)) (typeSeq (removeSeqPoly o))
     
     let mkStringValueType trust clearance sharing =
         mkValueType (typeApp (typeApp primStringCtor trust) clearance) sharing
@@ -204,7 +204,7 @@ module TypeBuilder =
         mkValueType (typeApp primListCtor elem) sharing
     
     let mkTupleType elems sharing =
-        mkValueType (typeApp primTupleCtor (typeSeq elems primValueKind)) sharing
+        mkValueType (typeApp primTupleCtor (typeSeq elems)) sharing
 
     let mkRowExtend elem row =
         typeApp (typeApp (TRowExtend (typeKindExn elem)) elem) row

--- a/Boba.Core/Types.fs
+++ b/Boba.Core/Types.fs
@@ -470,14 +470,9 @@ module Types =
             match ts with
             | ts when DotSeq.any isSeq ts && DotSeq.any isInd ts -> raise (MixedDataAndNestedSequences ts)
             | DotSeq.SInd (ht, tss) when DotSeq.all isInd tss ->
-                gatherKind (typeKindExn ht) (DotSeq.toList tss |> List.map typeKindExn)
+                KSeq (gatherKind (typeKindExn ht) (DotSeq.toList tss |> List.map typeKindExn))
             | ts when DotSeq.all isInd ts -> KSeq k
             | ts -> DotSeq.map typeKindExn ts |> maxKindsExn
-        //| TSeq (ts, k) ->
-        //    match ts with
-        //    | ts when DotSeq.all isInd ts -> KSeq k
-        //    | ts when DotSeq.any isSeq ts && DotSeq.any isInd ts -> raise (MixedDataAndNestedSequences ts)
-        //    | ts -> DotSeq.map typeKindExn ts |> maxKindsExn
         | TApp (l, r) -> applyKindExn (typeKindExn l) (typeKindExn r)
     
     let isTypeWellKinded ty =
@@ -507,7 +502,7 @@ module Types =
         | TRowExtend k -> TRowExtend (kindSubst subst k)
         | TEmptyRow k -> TEmptyRow (kindSubst subst k)
 
-        | TSeq (ts, k) -> TSeq (DotSeq.map (typeKindSubstExn subst) ts, k)
+        | TSeq (ts, k) -> TSeq (DotSeq.map (typeKindSubstExn subst) ts, (kindSubst subst k))
         | TApp (l, r) -> TApp (typeKindSubstExn subst l, typeKindSubstExn subst r)
         | _ -> t
 

--- a/Boba.Core/Types.fs
+++ b/Boba.Core/Types.fs
@@ -143,10 +143,10 @@ module Types =
         TCon (
             PrimFunctionCtorName,
             karrow (krow primEffectKind)
-                    (karrow (krow primPermissionKind)
-                        (karrow primTotalityKind
-                            (karrow (kseq primValueKind)
-                                (karrow (kseq primValueKind) primDataKind)))))
+                (karrow (krow primPermissionKind)
+                    (karrow primTotalityKind
+                        (karrow (kseq primValueKind)
+                            (karrow (kseq primValueKind) primDataKind)))))
     /// A tracked value is a data type with a sharing and validity annotation applied to it.
     /// Since sharing analysis is so viral, value-kinded types end up being the arguments
     /// required by most other types, since in Boba a data type without a sharing annotation
@@ -594,11 +594,7 @@ module Types =
         | TApp (l, TSeq (rs, k)) ->
             // special case for type constructors that take sequences as arguments: don't bubble last nested substitution sequence up!
             // instead, the constructor takes those most nested sequences as an argument
-            let canApplySeq =
-                match typeKindExn l with
-                | KArrow (arg, _) -> kindEq arg (typeKindExn (TSeq (rs, k)))
-                | _ -> false
-            if canApplySeq
+            if canApplyKind (typeKindExn l) (typeKindExn (TSeq (rs, k)))
             then typeApp l (TSeq (rs, k))
             else
                 try

--- a/Boba.Core/Unification.fs
+++ b/Boba.Core/Unification.fs
@@ -8,72 +8,124 @@ module Unification =
     open Types
 
     type UnifyConstraint =
-        | UCKind of Kind * Kind
-        | UCTypeSyn of Type * Type
-        | UCTypeBool of Boolean.Equation * Boolean.Equation * Kind
-        | UCTypeFixed of Abelian.Equation<string, int> * Abelian.Equation<string, int>
-        | UCTypeAbelian of Abelian.Equation<string, string> * Abelian.Equation<string, string> * Kind
-        | UCTypeSeq of DotSeq.DotSeq<Type> * DotSeq.DotSeq<Type>
-        | UCTypeRow of RowType * RowType
+        | UCKindEq of Kind * Kind
+        | UCKindMatch of Kind * Kind
+        | UCTypeEqSyn of Type * Type
+        | UCTypeEqBool of Boolean.Equation * Boolean.Equation * Kind
+        | UCTypeEqFixed of Abelian.Equation<string, int> * Abelian.Equation<string, int>
+        | UCTypeEqAbelian of Abelian.Equation<string, string> * Abelian.Equation<string, string> * Kind
+        | UCTypeEqSeq of DotSeq.DotSeq<Type> * DotSeq.DotSeq<Type> * Kind
+        | UCTypeEqRow of RowType * RowType
+        | UCTypeMatchSyn of Type * Type
+        | UCTypeMatchBool of Boolean.Equation * Boolean.Equation * Kind
+        | UCTypeMatchFixed of Abelian.Equation<string, int> * Abelian.Equation<string, int>
+        | UCTypeMatchAbelian of Abelian.Equation<string, string> * Abelian.Equation<string, string> * Kind
+        | UCTypeMatchSeq of DotSeq.DotSeq<Type> * DotSeq.DotSeq<Type> * Kind
+        | UCTypeMatchRow of RowType * RowType
         override this.ToString() =
             match this with
-            | UCKind (lk, rk) -> $"kind: {lk} ~~ {rk}"
-            | UCTypeSyn (lt, rt) -> $"type: {lt} ~~ {rt}"
-            | UCTypeBool (lb, rb, k) -> $"bool {k}: {lb} ~~ {rb}"
-            | UCTypeFixed (lf, rf) -> $"fixed: {lf} ~~ {rf}"
-            | UCTypeAbelian (la, ra, ak) -> $"abelian {ak}: {la} ~~ {ra}"
-            | UCTypeSeq (ls, rs) -> $"seq: {TSeq (ls, primValueKind)} ~~ {TSeq (rs, primValueKind)}"
-            | UCTypeRow (lr, rr) -> $"row: {lr} ~~ {rr}"
+            | UCKindEq (lk, rk) -> $"kind: {lk} ~~ {rk}"
+            | UCKindMatch (lk, rk) -> $"kind: {lk} ~> {rk}"
+            | UCTypeEqSyn (lt, rt) -> $"type: {lt} ~~ {rt}"
+            | UCTypeEqBool (lb, rb, k) -> $"bool {k}: {lb} ~~ {rb}"
+            | UCTypeEqFixed (lf, rf) -> $"fixed: {lf} ~~ {rf}"
+            | UCTypeEqAbelian (la, ra, ak) -> $"abelian {ak}: {la} ~~ {ra}"
+            | UCTypeEqSeq (ls, rs, k) -> $"seq {k}: {TSeq (ls, primValueKind)} ~~ {TSeq (rs, primValueKind)}"
+            | UCTypeEqRow (lr, rr) -> $"row: {lr} ~~ {rr}"
+            | UCTypeMatchSyn (lt, rt) -> $"type: {lt} ~> {rt}"
+            | UCTypeMatchBool (lb, rb, k) -> $"bool {k}: {lb} ~> {rb}"
+            | UCTypeMatchFixed (lf, rf) -> $"fixed: {lf} ~> {rf}"
+            | UCTypeMatchAbelian (la, ra, ak) -> $"abelian {ak}: {la} ~> {ra}"
+            | UCTypeMatchSeq (ls, rs, k) -> $"seq {k}: {TSeq (ls, primValueKind)} ~> {TSeq (rs, primValueKind)}"
+            | UCTypeMatchRow (lr, rr) -> $"row: {lr} ~> {rr}"
     
-    let kindEqConstraint = curry UCKind
-    let typeEqConstraint = curry UCTypeSyn
-    let booleanEqConstraint l r k = UCTypeBool (l, r, k)
-    let fixedEqConstraint = curry UCTypeFixed
-    let abelianEqConstraint l r k = UCTypeAbelian (l, r, k)
-    let sequenceEqConstraint = curry UCTypeSeq
-    let rowEqConstraint = curry UCTypeRow
+    let kindEqConstraint = curry UCKindEq
+    let kindMatchConstraint = curry UCKindMatch
+    let typeEqConstraint = curry UCTypeEqSyn
+    let booleanEqConstraint l r k = UCTypeEqBool (l, r, k)
+    let fixedEqConstraint = curry UCTypeEqFixed
+    let abelianEqConstraint l r k = UCTypeEqAbelian (l, r, k)
+    let sequenceEqConstraint l r k = UCTypeEqSeq (l, r, k)
+    let rowEqConstraint = curry UCTypeEqRow
+    let typeMatchConstraint = curry UCTypeMatchSyn
+    let booleanMatchConstraint l r k = UCTypeMatchBool (l, r, k)
+    let fixedMatchConstraint = curry UCTypeMatchFixed
+    let abelianMatchConstraint l r k = UCTypeMatchAbelian (l, r, k)
+    let sequenceMatchConstraint l r k = UCTypeMatchSeq (l, r, k)
+    let rowMatchConstraint = curry UCTypeMatchRow
 
     let constraintFreeWithKinds cnstr =
         match cnstr with
-        | UCKind _ -> Set.empty
-        | UCTypeSyn (lt, rt) ->
+        | UCKindEq _ -> Set.empty
+        | UCKindMatch _ -> Set.empty
+        | UCTypeEqSyn (lt, rt) ->
             Set.union (typeFreeWithKinds lt) (typeFreeWithKinds rt)
-        | UCTypeRow (lr, rr) ->
+        | UCTypeEqRow (lr, rr) ->
             Set.union (typeFreeWithKinds (rowToType lr)) (typeFreeWithKinds (rowToType rr))
-        | UCTypeSeq (ls, rs) ->
-            Set.union (typeFreeWithKinds (typeValueSeq ls)) (typeFreeWithKinds (typeValueSeq rs))
-        | UCTypeBool (lb, rb, bk) ->
+        | UCTypeEqSeq (ls, rs, k) ->
+            Set.union (typeFreeWithKinds (typeSeq ls k)) (typeFreeWithKinds (typeSeq rs k))
+        | UCTypeEqBool (lb, rb, bk) ->
             Set.union
                 (typeFreeWithKinds (booleanEqnToType bk lb))
                 (typeFreeWithKinds (booleanEqnToType bk rb))
-        | UCTypeAbelian (la, ra, ak) ->
+        | UCTypeEqAbelian (la, ra, ak) ->
             Set.union
                 (typeFreeWithKinds (abelianEqnToType ak la))
                 (typeFreeWithKinds (abelianEqnToType ak ra))
-        | UCTypeFixed (lf, rf) ->
+        | UCTypeEqFixed (lf, rf) ->
+            Set.union (typeFreeWithKinds (fixedEqnToType lf)) (typeFreeWithKinds (fixedEqnToType rf))
+        | UCTypeMatchSyn (lt, rt) ->
+            Set.union (typeFreeWithKinds lt) (typeFreeWithKinds rt)
+        | UCTypeMatchRow (lr, rr) ->
+            Set.union (typeFreeWithKinds (rowToType lr)) (typeFreeWithKinds (rowToType rr))
+        | UCTypeMatchSeq (ls, rs, k) ->
+            Set.union (typeFreeWithKinds (typeSeq ls k)) (typeFreeWithKinds (typeSeq rs k))
+        | UCTypeMatchBool (lb, rb, bk) ->
+            Set.union
+                (typeFreeWithKinds (booleanEqnToType bk lb))
+                (typeFreeWithKinds (booleanEqnToType bk rb))
+        | UCTypeMatchAbelian (la, ra, ak) ->
+            Set.union
+                (typeFreeWithKinds (abelianEqnToType ak la))
+                (typeFreeWithKinds (abelianEqnToType ak ra))
+        | UCTypeMatchFixed (lf, rf) ->
             Set.union (typeFreeWithKinds (fixedEqnToType lf)) (typeFreeWithKinds (fixedEqnToType rf))
     
     let constraintFree cnstr = constraintFreeWithKinds cnstr |> Set.map fst
 
     let rec constraintSubstExn fresh kSubst tSubst cnstr =
         match cnstr with
-        | UCKind (lk, rk) -> kindEqConstraint (kindSubst kSubst lk) (kindSubst kSubst rk)
-        | UCTypeSyn (lt, rt) ->
+        | UCKindEq (lk, rk) -> kindEqConstraint (kindSubst kSubst lk) (kindSubst kSubst rk)
+        | UCKindMatch (lk, rk) -> kindMatchConstraint (kindSubst kSubst lk) (kindSubst kSubst rk)
+        | UCTypeEqSyn (lt, rt) ->
             let ltk, rtk = typeKindSubstExn kSubst lt, typeKindSubstExn kSubst rt
             typeEqConstraint (typeSubstExn fresh tSubst ltk) (typeSubstExn fresh tSubst rtk)
-        | UCTypeRow (lr, rr) ->
-            let (UCTypeSyn (lrs, rrs)) = constraintSubstExn fresh kSubst tSubst (typeEqConstraint (rowToType lr) (rowToType rr))
+        | UCTypeEqRow (lr, rr) ->
+            let (UCTypeEqSyn (lrs, rrs)) = constraintSubstExn fresh kSubst tSubst (typeEqConstraint (rowToType lr) (rowToType rr))
             rowEqConstraint (typeToRow lrs) (typeToRow rrs)
-        | UCTypeSeq (ls, rs) ->
-            let (UCTypeSyn (TSeq (lss, _), TSeq (rss, _))) =
-                constraintSubstExn fresh kSubst tSubst (typeEqConstraint (TSeq (ls, primValueKind)) (TSeq (rs, primValueKind)))
-            sequenceEqConstraint lss rss
+        | UCTypeEqSeq (ls, rs, k) ->
+            let (UCTypeEqSyn (TSeq (lss, _), TSeq (rss, _))) =
+                constraintSubstExn fresh kSubst tSubst (typeEqConstraint (TSeq (ls, k)) (TSeq (rs, k)))
+            sequenceEqConstraint lss rss (kindSubst kSubst k)
+        | UCTypeMatchSyn (lt, rt) ->
+            let ltk, rtk = typeKindSubstExn kSubst lt, typeKindSubstExn kSubst rt
+            typeMatchConstraint (typeSubstExn fresh tSubst ltk) (typeSubstExn fresh tSubst rtk)
+        | UCTypeMatchRow (lr, rr) ->
+            let (UCTypeEqSyn (lrs, rrs)) = constraintSubstExn fresh kSubst tSubst (typeMatchConstraint (rowToType lr) (rowToType rr))
+            rowMatchConstraint (typeToRow lrs) (typeToRow rrs)
+        | UCTypeMatchSeq (ls, rs, k) ->
+            let (UCTypeEqSyn (TSeq (lss, _), TSeq (rss, _))) =
+                constraintSubstExn fresh kSubst tSubst (typeMatchConstraint (TSeq (ls, k)) (TSeq (rs, k)))
+            sequenceMatchConstraint lss rss (kindSubst kSubst k)
         // NOTE: this is only valid as bool, fixed, and abelian are solved instantly
         // after being appended to the solve list, and thus are never in the 'to-be-solved'
         // section that has composed substitutions applied to it
-        | UCTypeBool _ -> cnstr
-        | UCTypeFixed _ -> cnstr
-        | UCTypeAbelian _ -> cnstr
+        | UCTypeEqBool _ -> cnstr
+        | UCTypeEqFixed _ -> cnstr
+        | UCTypeEqAbelian _ -> cnstr
+        | UCTypeMatchBool _ -> cnstr
+        | UCTypeMatchFixed _ -> cnstr
+        | UCTypeMatchAbelian _ -> cnstr
 
     exception UnifyKindOccursCheckFailure of Kind * Kind
     exception UnifyKindMismatchException of Kind * Kind
@@ -86,17 +138,16 @@ module Unification =
     exception UnifyRowRigidMismatch of Type * Type
     exception UnifyRigidRigidMismatch of Type * Type
     exception UnifySequenceMismatch of DotSeq.DotSeq<Type> * DotSeq.DotSeq<Type>
-    exception UnifyNonValueSequence of Type * Type
     
     /// Utility method for when a unification step only breaks down the unification
     /// problem, and does not partially construct the result substitution.
-    let unifyDecompose cnstrs = Map.empty, Map.empty, cnstrs
+    let constraintDecompose cnstrs = Map.empty, Map.empty, cnstrs
 
     /// Simple syntactic unification of kinds.
     let unifyKind lk rk =
         match lk, rk with
         | _ when lk = rk ->
-            unifyDecompose []
+            constraintDecompose []
         | KVar v, _ when Set.contains v (kindFree rk) ->
             raise (UnifyKindOccursCheckFailure (lk, rk))
         | _, KVar v when Set.contains v (kindFree lk) ->
@@ -106,11 +157,11 @@ module Unification =
         | _, KVar v ->
             Map.empty, Map.add v lk Map.empty, []
         | KRow rl, KRow rr ->
-            unifyDecompose [kindEqConstraint rl rr]
+            constraintDecompose [kindEqConstraint rl rr]
         | KSeq sl, KSeq sr ->
-            unifyDecompose [kindEqConstraint sl sr]
+            constraintDecompose [kindEqConstraint sl sr]
         | KArrow (ll, lr), KArrow (rl, rr) ->
-            unifyDecompose [kindEqConstraint ll rl; kindEqConstraint lr rr]
+            constraintDecompose [kindEqConstraint ll rl; kindEqConstraint lr rr]
         | _ ->
             raise (UnifyKindMismatchException (lk, rk))
 
@@ -120,29 +171,29 @@ module Unification =
     let unifyType lt rt =
         match lt, rt with
         | _ when lt = rt ->
-            unifyDecompose []
+            constraintDecompose []
         | (TAnd _ | TOr _ | TNot _), _ ->
-            unifyDecompose [
+            constraintDecompose [
                 booleanEqConstraint
                     (typeToBooleanEqn (simplifyType lt))
                     (typeToBooleanEqn (simplifyType rt))
                     (typeKindExn lt)]
         | _, (TAnd _ | TOr _ | TNot _) ->
-            unifyDecompose [
+            constraintDecompose [
                 booleanEqConstraint
                     (typeToBooleanEqn (simplifyType lt))
                     (typeToBooleanEqn (simplifyType rt))
                     (typeKindExn lt)]
         | _ when typeKindExn lt = primFixedKind || typeKindExn rt = primFixedKind ->
-            unifyDecompose [
+            constraintDecompose [
                 fixedEqConstraint (typeToFixedEqn lt) (typeToFixedEqn rt);
                 kindEqConstraint (typeKindExn lt) (typeKindExn rt)]
         | _ when isKindAbelian (typeKindExn lt) || isKindAbelian (typeKindExn rt) ->
-            unifyDecompose [
+            constraintDecompose [
                 abelianEqConstraint (typeToUnitEqn lt) (typeToUnitEqn rt) (typeKindExn lt);
                 kindEqConstraint (typeKindExn lt) (typeKindExn rt)]
         | _ when isKindExtensibleRow (typeKindExn lt) || isKindExtensibleRow (typeKindExn rt) ->
-            unifyDecompose [rowEqConstraint (typeToRow lt) (typeToRow rt)]
+            constraintDecompose [rowEqConstraint (typeToRow lt) (typeToRow rt)]
         | TDotVar _, _ -> failwith "Dot vars should only occur in boolean types."
         | _, TDotVar _ -> failwith "Dot vars should only occur in boolean types."
         | TVar (nl, _), r when Set.contains nl (typeFree r) ->
@@ -153,14 +204,12 @@ module Unification =
             Map.add nl r Map.empty, Map.empty, [kindEqConstraint k (typeKindExn r)]
         | l, TVar (nr, k) ->
             Map.add nr l Map.empty, Map.empty, [kindEqConstraint k (typeKindExn l)]
-        | _ when typeKindExn lt <> typeKindExn rt ->
-            raise (UnifyTypeKindMismatch (lt, rt, typeKindExn lt, typeKindExn rt))
+        | TCon (ln, lk), TCon (rn, rk) when ln = rn ->
+            Map.empty, Map.empty, [kindEqConstraint lk rk]
         | TApp (ll, lr), TApp (rl, rr) ->
-            unifyDecompose [typeEqConstraint ll rl; typeEqConstraint lr rr]
-        | TSeq (ls, lk), TSeq (rs, rk) when lk = rk && lk = primValueKind ->
-            unifyDecompose [sequenceEqConstraint ls rs]
-        | TSeq _, TSeq _ ->
-            raise (UnifyNonValueSequence (lt, rt))
+            constraintDecompose [typeEqConstraint ll rl; typeEqConstraint lr rr]
+        | TSeq (ls, lk), TSeq (rs, rk) ->
+            constraintDecompose [kindEqConstraint lk rk; sequenceEqConstraint ls rs lk]
         | _ ->
             raise (UnifyRigidRigidMismatch (lt, rt))
     
@@ -207,9 +256,9 @@ module Unification =
         | DotSeq.SEnd, DotSeq.SEnd ->
             Map.empty, Map.empty, []
         | DotSeq.SInd (li, lss), DotSeq.SInd (ri, rss) ->
-            unifyDecompose [typeEqConstraint li ri; sequenceEqConstraint lss rss]
+            constraintDecompose [typeEqConstraint li ri; sequenceEqConstraint lss rss primValueKind]
         | DotSeq.SDot (ld, DotSeq.SEnd), DotSeq.SDot (rd, DotSeq.SEnd) ->
-            unifyDecompose [typeEqConstraint ld rd]
+            constraintDecompose [typeEqConstraint ld rd]
         | DotSeq.SDot (li, DotSeq.SEnd), DotSeq.SEnd ->
             [for (v, k) in List.ofSeq (typeFreeWithKinds li) do (v, TSeq (DotSeq.SEnd, k))] |> Map.ofList, Map.empty, []
         | DotSeq.SEnd, DotSeq.SDot (ri, DotSeq.SEnd) ->
@@ -273,7 +322,7 @@ module Unification =
                 Map.empty,
                 [kindEqConstraint leftRow.ElementKind rightRow.ElementKind]
             | None, None ->
-                unifyDecompose [kindEqConstraint leftRow.ElementKind rightRow.ElementKind]
+                constraintDecompose [kindEqConstraint leftRow.ElementKind rightRow.ElementKind]
         | ls, [] ->
             match rightRow.RowEnd with
             | Some rv ->
@@ -297,7 +346,7 @@ module Unification =
                 // this means the resulting lists are smaller, which guarantees termination
                 let label = Set.minElement overlapped
                 let (lElem, rElem), (lRest, rRest) = decomposeMatchingLabel label leftRow rightRow
-                unifyDecompose [
+                constraintDecompose [
                     typeEqConstraint lElem rElem;
                     rowEqConstraint { leftRow with Elements = lRest } { rightRow with Elements = rRest }]
             else
@@ -319,13 +368,13 @@ module Unification =
     /// and any more steps that need to be taken to fully solve the constraint.
     let solveStep fresh uc =
         match uc with
-        | UCKind (lk, rk) -> unifyKind lk rk
-        | UCTypeSyn (lt, rt) -> unifyType lt rt
-        | UCTypeBool (lb, rb, bk) -> unifyBoolean lb rb bk
-        | UCTypeFixed (lf, rf) -> unifyFixed fresh lf rf
-        | UCTypeAbelian (la, ra, ak) -> unifyAbelian fresh la ra ak
-        | UCTypeSeq (ls, rs) -> unifySequence fresh ls rs
-        | UCTypeRow (lr, rr) -> unifyRow fresh lr rr
+        | UCKindEq (lk, rk) -> unifyKind lk rk
+        | UCTypeEqSyn (lt, rt) -> unifyType lt rt
+        | UCTypeEqBool (lb, rb, bk) -> unifyBoolean lb rb bk
+        | UCTypeEqFixed (lf, rf) -> unifyFixed fresh lf rf
+        | UCTypeEqAbelian (la, ra, ak) -> unifyAbelian fresh la ra ak
+        | UCTypeEqSeq (ls, rs, k) -> unifySequence fresh ls rs
+        | UCTypeEqRow (lr, rr) -> unifyRow fresh lr rr
     
     /// Solve the given list of constraints from front to back. Returns the substitution
     /// that represents the most general unifier for all the constraints.


### PR DESCRIPTION
Should prevent a few weird kind propagation bugs. Added a good number of compiler unit tests for the kind system as well