### PR TITLE
Fix some type soundness issues with instances of overloads

### DIFF
--- a/Boba.Compiler/UnitImport.fs
+++ b/Boba.Compiler/UnitImport.fs
@@ -69,7 +69,7 @@ module UnitImport =
                 Unit = stringToSmallName "core"
                 Major = intToLiteral "0"
                 Minor = intToLiteral "0"
-                Patch = intToLiteral "21"
+                Patch = intToLiteral "22"
             } }]
 
     let rec loadDependencies alreadySeen imports loaded =

--- a/Boba.Core.Test/UnificationTests.fs
+++ b/Boba.Core.Test/UnificationTests.fs
@@ -107,3 +107,12 @@ let ``Unify fail: one: a, b... ~ two: c, b...`` () =
         typeUnifyExn (new SimpleFresh(0))
             (typeApp (typeApp (TRowExtend primFieldKind) (typeApp (typeCon "one" (karrow primValueKind primFieldKind)) (typeVar "a" primValueKind))) (typeVar "b" (KRow primFieldKind)))
             (typeApp (typeApp (TRowExtend primFieldKind) (typeApp (typeCon "two" (karrow primValueKind primFieldKind)) (typeVar "c" primValueKind))) (typeVar "b" (KRow primFieldKind))) |> ignore)
+    
+
+
+[<Fact>]
+let ``Strict match fail: a... ~> io!, c...`` () =
+    Assert.Throws<MatchRowMismatch>(fun () ->
+        strictTypeMatchExn (new SimpleFresh(0))
+            (typeVar "a" (krow primEffectKind))
+            (typeApp (typeApp (TRowExtend primEffectKind) (typeCon "io!" primEffectKind)) (typeVar "c" (krow primEffectKind))) |> ignore)

--- a/Boba.Core/Environment.fs
+++ b/Boba.Core/Environment.fs
@@ -13,6 +13,7 @@ module Environment =
         Pred: string;
         Template: TypeScheme;
         Instances: List<TypeScheme * string>;
+        Params: List<string>;
     }
 
     type TypeEnvironment = {
@@ -46,7 +47,7 @@ module Environment =
 
     let addPattern env name ty = { env with Patterns = Map.add name ty env.Patterns }
 
-    let addOverload env name pred template insts = { env with Overloads = Map.add name { Pred = pred; Template = template; Instances = insts } env.Overloads }
+    let addOverload env name pred template pars insts = { env with Overloads = Map.add name { Pred = pred; Template = template; Instances = insts; Params = pars } env.Overloads }
 
     let addRule env rule = { env with Rules = rule :: env.Rules }
 

--- a/test/correct-test/fundeps.boba
+++ b/test/correct-test/fundeps.boba
@@ -2,7 +2,7 @@
 overload extract as Extract? coll el
     : z... coll ===[ e... ][ p... ][ True ]==> z... el
 
-instance extract : [| b^r... a^s |]^(s || (r...)) a^s
+instance extract : [| b^r... a^s |]^((r...) || s) a^s
     = head-tuple
 
 instance extract : [a^s]^(s || r) a^s

--- a/test/wrong/instance-extra-effect.boba
+++ b/test/wrong/instance-extra-effect.boba
@@ -1,0 +1,7 @@
+overload eq as Eq? a
+    : z... a^s a^r ===[ e... ][ p... ][ True ]==> z... Bool^q
+
+instance eq : Bool
+    = eq-bool "print" clear-string print-string
+
+export { }


### PR DESCRIPTION
This will prevent leaking effects that are handled in an overload that does not declare them. A bit constricting, but solves the type soundness problem for now.